### PR TITLE
Add execution engine tests

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,40 @@
+import os
+from unittest.mock import MagicMock
+import pytest
+
+from execution import ExecutionEngine, MAX_NOTIONAL
+
+os.environ["TESTING"] = "1"
+
+
+def make_engine(pv=100000, price=10, position=None):
+    eng = ExecutionEngine()
+    eng.api.get_account.return_value = MagicMock(portfolio_value=str(pv))
+    eng.api.get_latest_trade.return_value = MagicMock(price=str(price))
+    if position is None:
+        eng.api.get_position.side_effect = Exception("no position")
+    else:
+        eng.api.get_position.return_value = MagicMock(market_value=str(position))
+    return eng
+
+
+def test_risk_guard():
+    eng = make_engine()
+    with pytest.raises(ValueError):
+        eng._risk(MAX_NOTIONAL + 1)
+
+
+def test_small_order_returns_none():
+    eng = make_engine(pv=100000, price=50)
+    order = eng.order_to_pct("AAPL", 0.0002)
+    assert order is None
+    eng.api.submit_order.assert_not_called()
+
+
+def test_valid_order_calls_submit():
+    eng = make_engine(pv=100000, price=10)
+    mock_order = MagicMock()
+    eng.api.submit_order.return_value = mock_order
+    order = eng.order_to_pct("AAPL", 0.1)
+    eng.api.submit_order.assert_called_once_with("AAPL", 1000.0, "buy", "market", "day")
+    assert order is mock_order


### PR DESCRIPTION
## Summary
- test ExecutionEngine behavior with mocked Alpaca client
- check notional guard
- ensure small orders return None
- verify orders submit correctly

## Testing
- `export TESTING=1 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b3ff2d388323b42c6b2252080f76