### PR TITLE
Add API key header check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Portfolio Allocation System
+
+This project provides a set of utilities for allocating and rebalancing
+quantitative trading portfolios.  A small FastAPI service is included in
+`api.py` for simple HTTP access.
+
+## API authentication
+
+All endpoints expect an API key to be passed using the `x-api-key` HTTP
+header.  The key value is read from the `API_KEY` environment variable at
+startup.  If the variable is unset, requests do not require a key.
+
+Example request:
+
+```bash
+curl -H "x-api-key: <your key>" http://localhost:8000/ping
+```

--- a/api.py
+++ b/api.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, Header, HTTPException, Depends
+from database import pf_coll
+from config import API_KEY
+
+app = FastAPI()
+
+
+def verify_api_key(x_api_key: str | None = Header(default=None)):
+    """Validate the API key from the ``x-api-key`` header."""
+    if API_KEY and x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+@app.get("/ping")
+def ping(dep: None = Depends(verify_api_key)):
+    """Basic health check."""
+    return {"status": "ok"}
+
+
+@app.get("/portfolios")
+def list_portfolios(dep: None = Depends(verify_api_key)):
+    """Return all portfolio names."""
+    names = [p.get("name") for p in pf_coll.find({}, {"name": 1})]
+    return {"portfolios": names}

--- a/config.py
+++ b/config.py
@@ -15,6 +15,10 @@ DB_NAME           = os.getenv("DB_NAME", "quant_fund")
 MIN_ALLOC         = float(os.getenv("MIN_ALLOCATION", 0.02))
 MAX_ALLOC         = float(os.getenv("MAX_ALLOCATION", 0.40))
 
+# Optional API key used by the HTTP service.  If set, all requests must
+# include this value in the ``x-api-key`` header.
+API_KEY           = os.getenv("API_KEY")
+
 CRON = {
     "monthly": {"day": "1",  "hour": 3, "minute": 0},
     "weekly" : {"day_of_week": "mon", "hour": 3, "minute": 0},


### PR DESCRIPTION
## Summary
- introduce `API_KEY` env var in `config.py`
- create `api.py` with FastAPI service
- add auth dependency checking `x-api-key` header
- document header usage in `README.md`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68666d441de883238ee189539097ec97