### PR TITLE
Add DC insider and government contract scrapers

### DIFF
--- a/database.py
+++ b/database.py
@@ -27,6 +27,10 @@ if os.getenv("TESTING"):
     trade_coll = DummyCollection(name="trade_coll")
     metric_coll = DummyCollection(name="metric_coll")
     politician_coll = DummyCollection(name="politician_coll")
+    lobbying_coll = DummyCollection(name="lobbying_coll")
+    wiki_coll = DummyCollection(name="wiki_coll")
+    insider_coll = DummyCollection(name="insider_coll")
+    contracts_coll = DummyCollection(name="contracts_coll")
     cache = DummyCollection(name="cache")
     db = adb = None
 else:
@@ -40,6 +44,10 @@ else:
     trade_coll = db["trades"]
     metric_coll = db["metrics"]
     politician_coll = db["politician_trades"]
+    lobbying_coll = db["lobbying"]
+    wiki_coll = db["wiki_views"]
+    insider_coll = db["dc_insider_scores"]
+    contracts_coll = db["gov_contracts"]
     cache = db["cache"]
 
     trade_coll.create_index([("portfolio_id", ASCENDING), ("timestamp", ASCENDING)])

--- a/scrapers/__init__.py
+++ b/scrapers/__init__.py
@@ -1,0 +1,18 @@
+from .politician import fetch_politician_trades, politician_coll
+from .lobbying import fetch_lobbying_data, lobby_coll
+from .wiki import fetch_wiki_views, wiki_collection
+from .dc_insider import fetch_dc_insider_scores, insider_coll
+from .gov_contracts import fetch_gov_contracts, contracts_coll
+
+__all__ = [
+    'fetch_politician_trades',
+    'fetch_lobbying_data',
+    'fetch_wiki_views',
+    'fetch_dc_insider_scores',
+    'fetch_gov_contracts',
+    'politician_coll',
+    'lobby_coll',
+    'wiki_collection',
+    'insider_coll',
+    'contracts_coll',
+]

--- a/scrapers/dc_insider.py
+++ b/scrapers/dc_insider.py
@@ -1,0 +1,38 @@
+import datetime as dt
+from typing import List
+from bs4 import BeautifulSoup
+from config import QUIVER_RATE_SEC
+from infra.rate_limiter import AsyncRateLimiter
+from infra.smart_scraper import get as scrape_get
+from database import db, pf_coll
+
+# fallback to pf_coll when db not available in testing
+insider_coll = db["dc_insider_scores"] if db else pf_coll
+rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+
+async def fetch_dc_insider_scores() -> List[dict]:
+    """Scrape DC Insider scores from QuiverQuant."""
+    url = "https://www.quiverquant.com/sources/dcinsiderscore"
+    async with rate:
+        html = await scrape_get(url)
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table")
+    data: List[dict] = []
+    now = dt.datetime.utcnow()
+    if table:
+        for row in table.find_all("tr")[1:]:
+            cells = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cells) >= 3:
+                item = {
+                    "ticker": cells[0],
+                    "score": cells[1],
+                    "date": cells[2],
+                    "_retrieved": now,
+                }
+                data.append(item)
+                insider_coll.update_one(
+                    {"ticker": item["ticker"], "date": item["date"]},
+                    {"$set": item},
+                    upsert=True,
+                )
+    return data

--- a/scrapers/gov_contracts.py
+++ b/scrapers/gov_contracts.py
@@ -1,0 +1,37 @@
+import datetime as dt
+from typing import List
+from bs4 import BeautifulSoup
+from config import QUIVER_RATE_SEC
+from infra.rate_limiter import AsyncRateLimiter
+from infra.smart_scraper import get as scrape_get
+from database import db, pf_coll
+
+contracts_coll = db["gov_contracts"] if db else pf_coll
+rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+
+async def fetch_gov_contracts() -> List[dict]:
+    """Scrape top government contract recipients from QuiverQuant."""
+    url = "https://www.quiverquant.com/sources/governmentcontracts"
+    async with rate:
+        html = await scrape_get(url)
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table")
+    data: List[dict] = []
+    now = dt.datetime.utcnow()
+    if table:
+        for row in table.find_all("tr")[1:]:
+            cells = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cells) >= 3:
+                item = {
+                    "ticker": cells[0],
+                    "value": cells[1],
+                    "date": cells[2],
+                    "_retrieved": now,
+                }
+                data.append(item)
+                contracts_coll.update_one(
+                    {"ticker": item["ticker"], "date": item["date"]},
+                    {"$set": item},
+                    upsert=True,
+                )
+    return data

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -1,0 +1,39 @@
+import datetime as dt
+from typing import List
+from bs4 import BeautifulSoup
+from config import QUIVER_RATE_SEC
+from infra.rate_limiter import AsyncRateLimiter
+from infra.smart_scraper import get as scrape_get
+from database import db, pf_coll, lobbying_coll
+
+# fallback to pf_coll when db not available in testing
+lobby_coll = lobbying_coll if db else pf_coll
+rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+
+async def fetch_lobbying_data() -> List[dict]:
+    """Scrape corporate lobbying spending from QuiverQuant."""
+    url = "https://www.quiverquant.com/sources/lobbying"
+    async with rate:
+        html = await scrape_get(url)
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table")
+    data = []
+    now = dt.datetime.utcnow()
+    if table:
+        for row in table.find_all("tr")[1:]:
+            cells = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cells) >= 4:
+                item = {
+                    "ticker": cells[0],
+                    "client": cells[1],
+                    "amount": cells[2],
+                    "date": cells[3],
+                    "_retrieved": now,
+                }
+                data.append(item)
+                lobby_coll.update_one(
+                    {"ticker": item["ticker"], "date": item["date"]},
+                    {"$set": item},
+                    upsert=True,
+                )
+    return data

--- a/scrapers/politician.py
+++ b/scrapers/politician.py
@@ -1,0 +1,42 @@
+import datetime as dt
+from typing import List
+from bs4 import BeautifulSoup
+from config import QUIVER_RATE_SEC
+from infra.rate_limiter import AsyncRateLimiter
+from infra.smart_scraper import get as scrape_get
+from database import db, pf_coll
+
+politician_coll = db["politician_trades"] if db else pf_coll
+rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+
+async def fetch_politician_trades() -> List[dict]:
+    url = "https://www.quiverquant.com/sources/politician-trading"
+    async with rate:
+        html = await scrape_get(url)
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table")
+    data = []
+    now = dt.datetime.utcnow()
+    if table:
+        for row in table.find_all("tr")[1:]:
+            cells = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cells) >= 5:
+                item = {
+                    "politician": cells[0],
+                    "ticker": cells[1],
+                    "transaction": cells[2],
+                    "amount": cells[3],
+                    "date": cells[4],
+                    "_retrieved": now,
+                }
+                data.append(item)
+                politician_coll.update_one(
+                    {
+                        "politician": item["politician"],
+                        "ticker": item["ticker"],
+                        "date": item["date"],
+                    },
+                    {"$set": item},
+                    upsert=True,
+                )
+    return data

--- a/scrapers/wiki.py
+++ b/scrapers/wiki.py
@@ -1,0 +1,37 @@
+import datetime as dt
+from typing import List
+from bs4 import BeautifulSoup
+from config import QUIVER_RATE_SEC
+from infra.rate_limiter import AsyncRateLimiter
+from infra.smart_scraper import get as scrape_get
+from database import db, pf_coll, wiki_coll
+
+wiki_collection = wiki_coll if db else pf_coll
+rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+
+async def fetch_wiki_views() -> List[dict]:
+    """Scrape most viewed company pages from QuiverQuant."""
+    url = "https://www.quiverquant.com/sources/wikipedia"
+    async with rate:
+        html = await scrape_get(url)
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table")
+    data = []
+    now = dt.datetime.utcnow()
+    if table:
+        for row in table.find_all("tr")[1:]:
+            cells = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cells) >= 3:
+                item = {
+                    "ticker": cells[0],
+                    "views": cells[1],
+                    "date": cells[2],
+                    "_retrieved": now,
+                }
+                data.append(item)
+                wiki_collection.update_one(
+                    {"ticker": item["ticker"], "date": item["date"]},
+                    {"$set": item},
+                    upsert=True,
+                )
+    return data

--- a/tests/test_api_scheduler.py
+++ b/tests/test_api_scheduler.py
@@ -1,0 +1,17 @@
+import os
+os.environ["TESTING"] = "1"
+import api
+
+
+def test_scheduler_endpoints():
+    api.sched.scheduler.remove_all_jobs()
+    job = api.ScheduleJob(
+        pf_id="demo",
+        name="Demo",
+        module="strategies.lobbying_growth",
+        cls="LobbyingGrowthStrategy",
+        cron_key="monthly",
+    )
+    api.add_job(job)
+    jobs = api.list_jobs()["jobs"]
+    assert any(j["id"] == "demo" for j in jobs)

--- a/tests/test_api_scraping.py
+++ b/tests/test_api_scraping.py
@@ -1,0 +1,86 @@
+import os
+os.environ["TESTING"] = "1"
+import asyncio
+import api
+from scrapers import politician, lobbying, wiki, dc_insider, gov_contracts
+
+async def fake_get(url):
+    if "politician" in url:
+        return """
+        <table>
+          <tr><th>Name</th><th>Ticker</th><th>Type</th><th>Amount</th><th>Date</th></tr>
+          <tr><td>John Doe</td><td>AAPL</td><td>Purchase</td><td>$10,000</td><td>2024-01-01</td></tr>
+        </table>
+        """
+    if "lobbying" in url:
+        return """
+        <table>
+          <tr><th>Ticker</th><th>Client</th><th>Amount</th><th>Date</th></tr>
+          <tr><td>AAPL</td><td>Firm</td><td>$5,000</td><td>2024-01-01</td></tr>
+        </table>
+        """
+    if "governmentcontracts" in url:
+        return """
+        <table>
+          <tr><th>Ticker</th><th>Value</th><th>Date</th></tr>
+          <tr><td>AAPL</td><td>$20,000</td><td>2024-01-01</td></tr>
+        </table>
+        """
+    if "dcinsiderscore" in url:
+        return """
+        <table>
+          <tr><th>Ticker</th><th>Score</th><th>Date</th></tr>
+          <tr><td>AAPL</td><td>75</td><td>2024-01-01</td></tr>
+        </table>
+        """
+    return """
+        <table>
+          <tr><th>Ticker</th><th>Views</th><th>Date</th></tr>
+          <tr><td>AAPL</td><td>1000</td><td>2024-01-01</td></tr>
+        </table>
+        """
+
+def test_fetch_politician_scrape(monkeypatch):
+    monkeypatch.setattr(politician, "scrape_get", fake_get)
+    inserted = {}
+    monkeypatch.setattr(api.politician_coll, "update_one", lambda q,u,upsert=None: inserted.update(u["$set"]))
+    data = asyncio.run(api.fetch_politician_trades())
+    assert len(data) == 1
+    assert inserted["ticker"] == "AAPL"
+
+
+def test_fetch_lobbying_scrape(monkeypatch):
+    monkeypatch.setattr(lobbying, "scrape_get", fake_get)
+    inserted = {}
+    monkeypatch.setattr(api.lobby_coll, "update_one", lambda q,u,upsert=None: inserted.update(u["$set"]))
+    data = asyncio.run(api.fetch_lobbying_data())
+    assert len(data) == 1
+    assert "client" in inserted
+
+
+def test_fetch_wiki_views_scrape(monkeypatch):
+    monkeypatch.setattr(wiki, "scrape_get", fake_get)
+    inserted = {}
+    monkeypatch.setattr(api.wiki_collection, "update_one", lambda q,u,upsert=None: inserted.update(u["$set"]))
+    data = asyncio.run(api.fetch_wiki_views())
+    assert len(data) == 1
+    assert inserted["ticker"] == "AAPL"
+
+
+def test_fetch_dc_insider_scrape(monkeypatch):
+    monkeypatch.setattr(dc_insider, "scrape_get", fake_get)
+    inserted = {}
+    monkeypatch.setattr(api.insider_coll, "update_one", lambda q,u,upsert=None: inserted.update(u["$set"]))
+    data = asyncio.run(api.fetch_dc_insider_scores())
+    assert len(data) == 1
+    assert inserted["score"] == "75"
+
+
+def test_fetch_gov_contracts_scrape(monkeypatch):
+    monkeypatch.setattr(gov_contracts, "scrape_get", fake_get)
+    inserted = {}
+    monkeypatch.setattr(api.contracts_coll, "update_one", lambda q,u,upsert=None: inserted.update(u["$set"]))
+    data = asyncio.run(api.fetch_gov_contracts())
+    assert len(data) == 1
+    assert inserted["value"] == "$20,000"
+


### PR DESCRIPTION
## Summary
- create scrapers for DC Insider scores and government contracts
- expose new collections via database helpers
- provide API endpoints for collecting and viewing these datasets
- extend tests for scraping utilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667065489c83239d430dfc2cbd505a