### PR TITLE
Improve frontend endpoints and auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# Agent Guide & Commit Conventions
+
+This document helps Codex (or any future agent) produce clear, consistent commits for the portfolio allocation system.
+
+---
+
+## 1. Agent Overview
+
+- **Purpose**: Automate feature development, bug fixes and documentation.
+- **Scope**: Data scraping, universe management, risk models, scheduling and reporting.
+- **Audience**: Developers and AI agents extending or maintaining the codebase.
+
+---
+
+## 2. Design Goals
+
+1. **Modularity**
+   - Keep scrapers, strategies, risk tools and analytics in separate modules.
+   - Document interfaces so implementations can be swapped easily.
+2. **Performance & Scalability**
+   - Cache network calls and batch requests when possible.
+   - Parallelise downloads where safe.
+3. **Robustness**
+   - Handle missing data and timeouts gracefully.
+   - Use adaptive thresholds to avoid empty outputs.
+4. **Extensibility**
+   - Models and data sources should be pluggable.
+   - Rolling windows (daily, weekly, monthly) must be configurable.
+5. **Observability**
+   - Provide structured logging and progress indicators.
+   - Maintain unit tests for critical logic.
+6. **Safety**
+   - Detect paper vs live Alpaca endpoints and require `allow_live=True` for real trading.
+   - Use the `AUTO_START_SCHED` flag so deployments can delay trading until explicitly enabled.
+
+---
+
+## 3. Repository Layout
+
+- `api.py` – REST interface for the front end.
+- `scheduler.py` – manages periodic strategy execution.
+- `execution/` – Alpaca gateway and execution helpers.
+- `analytics/` – metric collection and optimisation utilities.
+- `risk/` – exposure limits, correlation regimes and circuit breakers.
+- `strategies/` – individual trading strategies.
+- `infra/` – rate limiting and resilient scraping helpers.
+
+---
+
+## 4. Commit Message Guidelines
+
+Every commit should follow this template:
+
+```
+<summary line>
+
+- bullet describing first change
+- bullet describing next change
+
+Testing:
+- `pytest -q`
+```
+
+Additional rules:
+- Format all Python with **black** before committing.
+- Run `pytest -q` and include tests for new features when possible.
+- Update the README or docs whenever behaviour or configuration changes.
+- Keep commits focused and messages concise.

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -2,11 +2,15 @@ from .collector import record_snapshot
 from .covariance import estimate_covariance
 from .blacklitterman import market_implied_returns, black_litterman_posterior
 from .tracking import update_all_metrics
+from .robust import minmax_portfolio
+from .account import record_account
 
 __all__ = [
     "record_snapshot",
     "estimate_covariance",
     "market_implied_returns",
     "black_litterman_posterior",
+    "minmax_portfolio",
     "update_all_metrics",
+    "record_account",
 ]

--- a/analytics/account.py
+++ b/analytics/account.py
@@ -1,0 +1,27 @@
+"""Account level metrics collection."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict
+
+from database import db
+from execution.gateway import AlpacaGateway
+
+account_coll = db["account_metrics"]
+
+
+async def record_account(gateway: AlpacaGateway) -> Dict:
+    """Fetch account equity from Alpaca and store it."""
+    info = await gateway.account()
+    doc = {
+        "timestamp": dt.datetime.utcnow(),
+        "paper": gateway.paper,
+        "equity": float(info.get("equity", 0)),
+        "last_equity": float(info.get("last_equity", 0)),
+    }
+    account_coll.insert_one(doc)
+    return doc
+
+
+__all__ = ["record_account", "account_coll"]

--- a/analytics/robust.py
+++ b/analytics/robust.py
@@ -1,0 +1,30 @@
+"""Robust portfolio optimisation utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def minmax_portfolio(
+    mu: pd.Series,
+    cov: pd.DataFrame,
+    gamma: float = 1.0,
+    delta: float = 0.05,
+) -> pd.Series:
+    """Return weights from a simple min-max mean-variance optimisation.
+
+    The worst-case covariance is approximated by scaling ``cov`` by ``1 + delta``.
+    """
+    worst = cov * (1 + delta)
+    inv = np.linalg.pinv(gamma * worst)
+    w = inv @ mu.values
+    w = np.clip(w, 0, None)
+    if w.sum() > 0:
+        w = w / w.sum()
+    else:
+        w = np.ones(len(mu)) / len(mu)
+    return pd.Series(w, index=mu.index)
+
+
+__all__ = ["minmax_portfolio"]

--- a/config.py
+++ b/config.py
@@ -3,23 +3,28 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-ALPACA_API_KEY    = os.getenv("ALPACA_API_KEY")
+ALPACA_API_KEY = os.getenv("ALPACA_API_KEY")
 ALPACA_API_SECRET = os.getenv("ALPACA_API_SECRET")
-ALPACA_BASE_URL   = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+ALPACA_BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
 
-QUIVER_RATE_SEC   = float(os.getenv("QUIVER_RATE_SEC", 1.1))
+QUIVER_RATE_SEC = float(os.getenv("QUIVER_RATE_SEC", 1.1))
 
-MONGO_URI         = os.getenv("MONGO_URI", "mongodb://localhost:27017")
-DB_NAME           = os.getenv("DB_NAME", "quant_fund")
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("DB_NAME", "quant_fund")
 
-MIN_ALLOC         = float(os.getenv("MIN_ALLOCATION", 0.02))
-MAX_ALLOC         = float(os.getenv("MAX_ALLOCATION", 0.40))
+MIN_ALLOC = float(os.getenv("MIN_ALLOCATION", 0.02))
+MAX_ALLOC = float(os.getenv("MAX_ALLOCATION", 0.40))
 
-REDDIT_CLIENT_ID     = os.getenv("REDDIT_CLIENT_ID")
+REDDIT_CLIENT_ID = os.getenv("REDDIT_CLIENT_ID")
 REDDIT_CLIENT_SECRET = os.getenv("REDDIT_CLIENT_SECRET")
-REDDIT_USER_AGENT    = os.getenv("REDDIT_USER_AGENT", "WSB-Strategy/1.0")
+REDDIT_USER_AGENT = os.getenv("REDDIT_USER_AGENT", "WSB-Strategy/1.0")
+
+API_TOKEN = os.getenv("API_TOKEN")
 
 CRON = {
-    "monthly": {"day": "1",  "hour": 3, "minute": 0},
-    "weekly" : {"day_of_week": "mon", "hour": 3, "minute": 0},
+    "monthly": {"day": "1", "hour": 3, "minute": 0},
+    "weekly": {"day_of_week": "mon", "hour": 3, "minute": 0},
 }
+
+# Start the scheduler automatically when the API loads if set to "true".
+AUTO_START_SCHED = os.getenv("AUTO_START_SCHED", "false").lower() == "true"

--- a/database.py
+++ b/database.py
@@ -32,10 +32,15 @@ wiki_coll: Collection = db["wiki_views"]
 insider_coll: Collection = db["dc_insider_scores"]
 contracts_coll: Collection = db["gov_contracts"]
 cache: Collection = db["cache"]
+account_coll: Collection = db["account_metrics"]
 
 trade_coll.create_index([("portfolio_id", ASCENDING), ("timestamp", ASCENDING)])
-metric_coll.create_index([
-    ("portfolio_id", ASCENDING),
-    ("date", ASCENDING),
-], unique=True)
+metric_coll.create_index(
+    [
+        ("portfolio_id", ASCENDING),
+        ("date", ASCENDING),
+    ],
+    unique=True,
+)
 cache.create_index("expire", expireAfterSeconds=0)
+account_coll.create_index("timestamp")

--- a/infra/rate_limiter.py
+++ b/infra/rate_limiter.py
@@ -30,3 +30,22 @@ class AsyncRateLimiter:
                     self.cond.notify_all()
                     return
                 await self.cond.wait()
+
+
+class DynamicRateLimiter(AsyncRateLimiter):
+    """Rate limiter that expands the waiting period when backoff is triggered."""
+
+    def __init__(self, max_calls: int, period: float, factor: float = 2.0, max_period: float = 60.0) -> None:
+        super().__init__(max_calls, period)
+        self.base_period = period
+        self.factor = factor
+        self.max_period = max_period
+
+    def backoff(self) -> None:
+        """Increase the period exponentially up to ``max_period``."""
+        self.period = min(self.period * self.factor, self.max_period)
+
+    def reset(self) -> None:
+        """Reset the period to the original value."""
+        self.period = self.base_period
+

--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -4,6 +4,7 @@ from .exposure import gross_exposure, net_exposure
 from .var import historical_var, cvar
 from .circuit import CircuitBreaker
 from .position_risk import PositionRisk
+from .corr_regime import correlation_regime
 
 __all__ = [
     "gross_exposure",
@@ -12,4 +13,5 @@ __all__ = [
     "cvar",
     "CircuitBreaker",
     "PositionRisk",
+    "correlation_regime",
 ]

--- a/risk/corr_regime.py
+++ b/risk/corr_regime.py
@@ -1,0 +1,63 @@
+"""Rolling correlation regime detection."""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+
+def _vol_regime(returns: pd.DataFrame, window: int, high: float) -> bool:
+    """Return True if average rolling volatility exceeds ``high``."""
+    vol = returns.rolling(window).std().dropna()
+    if vol.empty:
+        return False
+    avg_vol = vol.mean(axis=1).iloc[-1]
+    return float(avg_vol) > high
+
+
+def correlation_regime(
+    returns: pd.DataFrame,
+    window: int = 60,
+    high: float = 0.7,
+    vol_high: float = 0.04,
+) -> str:
+    """Return the current correlation regime using a Gaussian mixture model.
+
+    Parameters
+    ----------
+    returns : pd.DataFrame
+        Asset returns.
+    window : int, default 60
+        Rolling window used to estimate average correlations.
+    high : float, default 0.7
+        Correlation threshold defining a high-correlation regime.
+    vol_high : float, default 0.04
+        Average rolling volatility above which the regime is considered ``"high"``.
+
+    Returns
+    -------
+    str
+        ``"high"`` if average correlation exceeds ``high`` else ``"normal"``.
+    """
+    if len(returns) < window:
+        return "normal"
+    roll_corr = returns.rolling(window).corr().groupby(level=0).mean().dropna()
+    avg_corr = roll_corr.mean(axis=1)
+    if len(avg_corr) < 2:
+        avg = avg_corr.iloc[-1]
+        if np.isnan(avg) or avg < high:
+            return "high" if _vol_regime(returns, window, vol_high) else "normal"
+        return "high"
+    gm = GaussianMixture(n_components=2, random_state=0)
+    gm.fit(avg_corr.to_frame("corr"))
+    label = gm.predict([[avg_corr.iloc[-1]]])[0]
+    means = gm.means_.ravel()
+    corr_high = means[label] > high
+    vol_high_flag = _vol_regime(returns, window, vol_high)
+    if corr_high or vol_high_flag:
+        return "high"
+    return "normal"
+
+
+__all__ = ["correlation_regime"]

--- a/scheduler.py
+++ b/scheduler.py
@@ -8,10 +8,16 @@ from core.equity import EquityPortfolio
 from execution_gateway import AlpacaGateway
 from allocation_engine import compute_weights
 from database import metric_coll
+from analytics import update_all_metrics, record_account
+
 _log = get_logger("sched")
+
+
 class StrategyScheduler:
     def __init__(self):
-        self.scheduler=AsyncIOScheduler(); self.portfolios={}
+        self.scheduler = AsyncIOScheduler()
+        self.portfolios = {}
+
     def add(self, pf_id, name, mod_path, cls_name, cron_key):
         strat_cls = getattr(import_module(mod_path), cls_name)
         pf = EquityPortfolio(name, gateway=AlpacaGateway(), pf_id=pf_id)
@@ -23,19 +29,45 @@ class StrategyScheduler:
             id=pf_id,
             **CRON[cron_key],
         )
+
     def start(self):
         async def realloc_job():
-            start=dt.datetime.utcnow()-dt.timedelta(days=90)
-            cur=metric_coll.find({"date":{"$gte":start.date()}},{"portfolio_id":1,"date":1,"ret":1})
-            df=pd.DataFrame(list(cur))
-            if df.empty: return
-            piv=df.pivot(index="date",columns="portfolio_id",values="ret").dropna(axis=1)
-            w=compute_weights(piv)
-            for pid,wt in w.items():
-                pf=self.portfolios.get(pid)
+            start = dt.datetime.utcnow() - dt.timedelta(days=90)
+            cur = metric_coll.find(
+                {"date": {"$gte": start.date()}},
+                {"portfolio_id": 1, "date": 1, "ret": 1},
+            )
+            df = pd.DataFrame(list(cur))
+            if df.empty:
+                return
+            piv = df.pivot(index="date", columns="portfolio_id", values="ret").dropna(
+                axis=1
+            )
+            w = compute_weights(piv)
+            for pid, wt in w.items():
+                pf = self.portfolios.get(pid)
                 if pf:
-                    new={sym:pct*wt for sym,pct in pf.weights.items()}
+                    new = {sym: pct * wt for sym, pct in pf.weights.items()}
                     pf.set_weights(new)
                     await pf.rebalance()
-        self.scheduler.add_job(realloc_job,"cron",day_of_week="fri",hour=21,minute=0,id="realloc")
+
+        def metrics_job():
+            update_all_metrics()
+
+        async def account_job():
+            gw = AlpacaGateway()
+            try:
+                await record_account(gw)
+            finally:
+                await gw.close()
+
+        self.scheduler.add_job(
+            realloc_job, "cron", day_of_week="fri", hour=21, minute=0, id="realloc"
+        )
+        self.scheduler.add_job(metrics_job, "cron", hour=0, minute=5, id="metrics")
+        self.scheduler.add_job(account_job, "cron", hour=0, minute=0, id="account")
         self.scheduler.start()
+
+    def stop(self):
+        """Stop all scheduled jobs without blocking."""
+        self.scheduler.shutdown(wait=False)

--- a/scrapers/analyst_ratings.py
+++ b/scrapers/analyst_ratings.py
@@ -6,10 +6,10 @@ from typing import Iterable, List
 import pandas as pd
 
 from infra.smart_scraper import get as scrape_get
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from config import QUIVER_RATE_SEC
 
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 
 async def _fetch_ticker(sym: str) -> pd.DataFrame:

--- a/scrapers/dc_insider.py
+++ b/scrapers/dc_insider.py
@@ -3,7 +3,7 @@ from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import QUIVER_RATE_SEC
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
 from database import db, pf_coll
 from pymongo.collection import Collection
@@ -11,7 +11,7 @@ from infra.data_store import append_snapshot
 
 # fallback to pf_coll when db not available in testing
 insider_coll: Collection = db["dc_insider_scores"] if db else pf_coll
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 async def fetch_dc_insider_scores() -> List[dict]:
     """Scrape DC Insider scores from QuiverQuant."""

--- a/scrapers/gov_contracts.py
+++ b/scrapers/gov_contracts.py
@@ -3,14 +3,14 @@ from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import QUIVER_RATE_SEC
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
 from database import db, pf_coll
 from pymongo.collection import Collection
 from infra.data_store import append_snapshot
 
 contracts_coll: Collection = db["gov_contracts"] if db else pf_coll
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 async def fetch_gov_contracts() -> List[dict]:
     """Scrape top government contract recipients from QuiverQuant."""

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -3,7 +3,7 @@ from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import QUIVER_RATE_SEC
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
 from database import db, pf_coll, lobbying_coll
 from pymongo.collection import Collection
@@ -12,7 +12,7 @@ from metrics import scrape_latency, scrape_errors
 
 # fallback to pf_coll when db not available in testing
 lobby_coll: Collection = lobbying_coll if db else pf_coll
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 async def fetch_lobbying_data() -> List[dict]:
     """Scrape corporate lobbying spending from QuiverQuant."""

--- a/scrapers/politician.py
+++ b/scrapers/politician.py
@@ -3,14 +3,14 @@ from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import QUIVER_RATE_SEC
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
 from database import db, pf_coll
 from pymongo.collection import Collection
 from infra.data_store import append_snapshot
 
 politician_coll: Collection = db["politician_trades"] if db else pf_coll
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 async def fetch_politician_trades() -> List[dict]:
     url = "https://www.quiverquant.com/sources/politician-trading"

--- a/scrapers/wiki.py
+++ b/scrapers/wiki.py
@@ -3,7 +3,7 @@ from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import QUIVER_RATE_SEC
-from infra.rate_limiter import AsyncRateLimiter
+from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
 from database import db, pf_coll, wiki_coll
 from pymongo.collection import Collection
@@ -11,7 +11,7 @@ from infra.data_store import append_snapshot
 from metrics import scrape_latency, scrape_errors
 
 wiki_collection: Collection = wiki_coll if db else pf_coll
-rate = AsyncRateLimiter(1, QUIVER_RATE_SEC)
+rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 
 async def fetch_wiki_views() -> List[dict]:
     """Scrape most viewed company pages from QuiverQuant."""

--- a/tests/test_account_metrics.py
+++ b/tests/test_account_metrics.py
@@ -1,0 +1,21 @@
+import asyncio
+import httpx
+import respx
+import pytest
+
+from analytics.account import record_account
+from execution.gateway import AlpacaGateway
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_record_account():
+    route = respx.get("https://paper-api.alpaca.markets/v2/account").mock(
+        return_value=httpx.Response(200, json={"equity": "1000", "last_equity": "900"})
+    )
+    gw = AlpacaGateway()
+    doc = await record_account(gw)
+    await gw.close()
+    assert route.called
+    assert doc["equity"] == 1000.0
+    assert doc["paper"] is True

--- a/tests/test_api_frontend.py
+++ b/tests/test_api_frontend.py
@@ -1,0 +1,35 @@
+import os
+import datetime as dt
+
+os.environ["MONGO_URI"] = "mongomock://localhost"
+os.environ["API_TOKEN"] = "secret"
+
+from fastapi.testclient import TestClient
+from api import app, metric_coll
+
+client = TestClient(app)
+HEADERS = {"Authorization": "Bearer secret"}
+
+
+def test_var_and_correlations():
+    metric_coll.delete_many({})
+    metric_coll.insert_many(
+        [
+            {"portfolio_id": "a", "date": dt.date(2024, 1, 1), "ret": 0.01},
+            {"portfolio_id": "a", "date": dt.date(2024, 1, 2), "ret": -0.02},
+            {"portfolio_id": "b", "date": dt.date(2024, 1, 1), "ret": 0.02},
+            {"portfolio_id": "b", "date": dt.date(2024, 1, 2), "ret": -0.01},
+        ]
+    )
+    r = client.get("/var", headers=HEADERS)
+    assert r.status_code == 200
+    assert "var" in r.json()
+
+    r = client.get("/correlations", headers=HEADERS)
+    assert r.status_code == 200
+    assert "correlations" in r.json()
+
+
+def test_auth_required():
+    resp = client.get("/portfolios")
+    assert resp.status_code == 401

--- a/tests/test_corr_regime.py
+++ b/tests/test_corr_regime.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from risk.corr_regime import correlation_regime
+
+
+def test_high_correlation_regime():
+    data = pd.DataFrame({"A": [0.05] * 60, "B": [0.05] * 60})
+    regime = correlation_regime(data, window=20, high=0.8, vol_high=0.04)
+    assert regime == "high"
+
+
+def test_normal_correlation_regime():
+    rng = pd.date_range("2023-01-01", periods=60)
+    data = pd.DataFrame(
+        {
+            "A": pd.Series(0.01, index=rng) + pd.Series(range(60)) / 10000,
+            "B": pd.Series(-0.01, index=rng) + pd.Series(range(60))[::-1] / 10000,
+        }
+    )
+    regime = correlation_regime(data, window=20, high=0.8, vol_high=0.04)
+    assert regime == "normal"

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,14 @@
+import asyncio
+import time
+
+import pytest
+
+from infra.rate_limiter import DynamicRateLimiter
+
+
+def test_dynamic_rate_limiter_backoff():
+    rate = DynamicRateLimiter(1, 0.1, factor=2.0, max_period=1.0)
+    rate.backoff()
+    assert rate.period > 0.1
+    rate.reset()
+    assert rate.period == 0.1


### PR DESCRIPTION
## Summary
- add API token auth middleware
- expose VaR, correlation matrix and SSE endpoints for frontend
- allow date filtering on analytics endpoint
- document new env var and endpoints
- test frontend features

## Testing
- `pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686afc1bc1d48323aa9969a9cfea25db