### PR TITLE
Rewrite README and lobbying strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,282 +1,79 @@
 # Portfolio Allocation System
 
-This project implements a minimal portfolio management API and scraping suite built with Python. It provides tools to schedule trading strategies, collect alternative data and record trades in a MongoDB database.
+The Portfolio Allocation System is a Python service for running data-driven trading strategies.  A FastAPI server exposes REST endpoints while a background scheduler executes portfolio updates.  Data scrapers load alternative data into MongoDB and DuckDB, and the execution gateway places orders through the Alpaca API.  Logging, metrics and optional distributed tracing provide full observability.
 
-Key features include:
-- Dynamic rate limiting with exponential backoff for all scrapers
-- Rolling correlation regime detection using a Gaussian mixture model
-- Robust portfolio optimisation with optional min–max solver
-- Scheduler that can be started or stopped via API or `AUTO_START_SCHED`
-- Safety checks for Alpaca paper vs live trading endpoints
-- Continuous analytics for each strategy and overall account equity
-- Daily account tracking and a `/stream/account` SSE endpoint
-- Optional API token authentication and real-time WebSocket streams
+## Technical Features
 
-## Prerequisites
+- **FastAPI Service** – async HTTP interface with token authentication
+- **APScheduler** – cron-like scheduler for strategy execution
+- **Alpaca Gateway** – unified wrapper around the Alpaca REST API with paper/live detection
+- **MongoDB + DuckDB** – persistent storage for trades, snapshots and alt-data
+- **Dynamic Scrapers** – rate limited fetchers for QuiverQuant datasets
+- **Risk Models** – covariance estimation, correlation regime detection and VaR
+- **Analytics** – daily statistics, Prometheus metrics and OpenTelemetry tracing
 
-- Python 3.12+
-- MongoDB instance (local or remote)
-- Optional: Alpaca brokerage account for trade execution
+## Financial Models
 
-## Installation
+Return and risk estimates feed into the allocation engine.  Let $r_t$ denote daily returns.
 
-1. **Clone the repository**
-   ```bash
-   git clone <repo_url>
-   cd Portfolio_Allocation_System
-   ```
-2. **Create a virtual environment** *(recommended)*
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   ```
-3. **Install Python dependencies**
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-## Configuration
-
-Environment variables control connections and limits. Create a `.env` file or export variables in your shell.
-
-- `ALPACA_API_KEY` and `ALPACA_API_SECRET` – credentials for Alpaca Trade API.
-- `ALPACA_BASE_URL` – API endpoint (default `https://paper-api.alpaca.markets`). Use the paper URL for testing and the live URL only when ready to trade.
-- `QUIVER_RATE_SEC` – seconds between scraper requests (default `1.1`).
-- `MONGO_URI` – MongoDB connection URI (default `mongodb://localhost:27017`).
-- `DB_NAME` – MongoDB database name (default `quant_fund`).
-- `MIN_ALLOCATION` and `MAX_ALLOCATION` – portfolio weight bounds.
-- `LOG_LEVEL` – logging verbosity (default `INFO`).
-- `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` – credentials for the Reddit API.
-- `REDDIT_USER_AGENT` – identifier string for Reddit requests (default `WSB-Strategy/1.0`).
-- `AUTO_START_SCHED` – set to `true` to launch the scheduler automatically when
-  the API starts. Otherwise call `/scheduler/start` once ready to trade.
-- `API_TOKEN` – if set, all endpoints require `Authorization: Bearer <token>`.
-
-## Running the API
-
-Start the FastAPI server with Uvicorn:
-```bash
-uvicorn api:app --reload
-```
-The API exposes JSON endpoints to manage portfolios, trigger scrapers and check
-scheduled jobs. It is designed to be consumed by a web front end in the future
-without further changes to the backend. See `api.py` for full route definitions.
-
-## Background Scheduler
-
-`StrategyScheduler` in `scheduler.py` runs trading strategies on a cron schedule using APScheduler. Strategies are Python classes under `strategies/` with a `build` coroutine that sets portfolio weights and executes trades.
-
-Example usage:
-```python
-from scheduler import StrategyScheduler
-sched = StrategyScheduler()
-sched.add('lobby', 'Lobbying', 'strategies.lobbying_growth', 'LobbyingGrowthStrategy', 'monthly')
-sched.start()  # or call `/scheduler/start` via the API
-```
-The scheduler also runs a weekly rebalancing job that uses metrics stored in MongoDB to compute new allocations via `allocation_engine.compute_weights`. When finished trading you can stop all jobs with `/scheduler/stop`.
-Daily performance data can be posted to the `/metrics/{pf_id}` endpoint. The API
-automatically updates trailing statistics such as Sharpe, Sortino, alpha, beta,
-tracking error and drawdown for each portfolio. These metrics feed directly into
-the allocation engine. You can refresh statistics for all portfolios with
-`/collect/metrics`, which downloads latest prices and updates each portfolio's
-metrics even when no positions are held. A daily scheduler task calls this
-endpoint automatically so strategy analytics are always captured even if the
-portfolio is inactive.
-
-## Scrapers
-
-Modules in `scrapers/` fetch datasets from QuiverQuant. Each function returns a list of records and stores them in the database:
-
-- `politician.py` – congressional trading disclosures
-- `lobbying.py` – corporate lobbying spending
-- `wiki.py` – Wikipedia page view statistics
-- `dc_insider.py` – insider sentiment and investor scores
-- `gov_contracts.py` – government contract awards
-
-Scrapers share a simple caching mechanism via `infra.smart_scraper.get` and now
-use a dynamic rate limiter with exponential backoff
-(`infra.rate_limiter.DynamicRateLimiter`). This adapts to transient 429 responses
-so scraping continues smoothly under heavy load.
-
-## Data Store
-
-All scraped records are normalised into a DuckDB database at `data/altdata.duckdb` in
-addition to MongoDB. Each scraper appends its table so historical snapshots are
-versioned automatically. See [docs/data_format.md](docs/data_format.md) for the list
-of tables and columns.
-
-## Portfolio Management
-
-`core/portfolio.py` provides an abstract `Portfolio` base class. `core/equity.py` implements an `EquityPortfolio` using an execution gateway. The default gateway `AlpacaGateway` wraps Alpaca's REST API and applies basic risk checks.
-
-`AlpacaGateway` automatically detects whether the configured endpoint is the paper trading API. When a live endpoint is used you must pass `allow_live=True` to its constructor, preventing accidental real-money trades.
-It also exposes an `account()` method to obtain equity information for both paper and live accounts.
-
-Weights are rebalanced to target percentages and all trades are recorded in MongoDB collections. Because Alpaca accounts do not support sub-portfolios, each order is tagged using `client_order_id` with the portfolio's identifier. Positions for a portfolio can be queried via the `/positions/{pf_id}` endpoint which aggregates executed trades.
-Individual positions can be closed via `POST /close/{pf_id}/{symbol}` which removes the symbol from the weight set and issues an order to exit.
-
-`Portfolio.rebalance` now closes stale positions as new weights are applied and leverages stored trade history rather than account-wide positions, ensuring clean separation between multiple portfolios hosted on the same Alpaca account.
-
-## Risk Management
-
-The `risk` package provides dynamic correlation regime detection using a
-Gaussian mixture model. You may swap in a Hidden Markov Model if desired.
-Rolling correlations trigger a de‑leveraging step when the market enters a
-high-correlation crisis regime. Covariance estimates rely on Ledoit–Wolf
-shrinkage by default with an optional min–max solver to guard against
-estimation error. Additional utilities calculate exposures, historical VaR and
-offer a `CircuitBreaker` to halt trading after large losses.
-
-## Analytics
-
-`analytics_utils.py` now exposes a wide range of statistics including Sharpe, Sortino,
-alpha, beta, tracking error, information ratio and maximum drawdown. The
-`allocation_engine.compute_weights` routine combines these measures to size
-portfolios dynamically while respecting volatility targets. Rebalancing jobs use
-the latest scraped data and stored returns so that portfolio adjustments do not
-introduce any look-ahead bias. Metrics are collected daily even when a
-portfolio holds no positions so performance history is always up to date.
-
-Account-level equity is also recorded daily. The scheduler calls
-`record_account` which stores equity and last equity for the configured
-Alpaca account, distinguishing between paper and live trading URLs.
-
-## Running Example
-
-An example entry point is provided in `start.py` which launches both the API server and scheduler. Execute:
-```bash
-python start.py
-```
-This will load any saved portfolios from the database and run until interrupted.
-
-### Key API Endpoints
-
-- `GET /portfolios` – list existing portfolios
-- `POST /portfolios` – create a new portfolio
-- `PUT /portfolios/{id}/weights` – update target weights
-- `POST /portfolios/{id}/rebalance` – place trades to match weights
-- `GET /positions/{id}` – current holdings
-- `POST /scheduler/start` and `POST /scheduler/stop` – control the allocation scheduler
-- `POST /close/{id}/{symbol}` – close a single position
-- `GET /metrics/{id}` – historical returns and statistics
-- `GET /var?start=&end=` – portfolio VaR and CVaR over a date range
-- `GET /correlations?start=&end=` – return correlation matrix of portfolio returns
-- `GET /stream/account` – server-sent events stream of account equity
-## Quickstart
-
-1. Launch a local MongoDB instance and optional Redis server:
-   ```bash
-   docker run -d --name mongo -p 27017:27017 mongo:7
-   docker run -d --name redis -p 6379:6379 redis:7
-   ```
-2. Set the required environment variables or edit `.env`.
-3. Run scrapers to populate the data store:
-   ```bash
-   python -m scrapers.politician
-   python -m scrapers.lobbying
-   python -m scrapers.wiki
-   python -m scrapers.dc_insider
-   python -m scrapers.gov_contracts
-   ```
-   Each run appends rows to `data/altdata.duckdb` and MongoDB collections.
-4. Start the API server with Uvicorn as shown above. The `/health` endpoint reports service status and `/metrics` exposes Prometheus data. The `/analytics/{portfolio}` endpoint returns rolling statistics computed from the stored snapshots.
+- **Sharpe Ratio** $\displaystyle S = \frac{\mathbb{E}[r_t]}{\sigma[r_t]}\sqrt{252}$
+- **Sortino Ratio** $\displaystyle S^- = \frac{\mathbb{E}[r_t]}{\sigma[r_t\,|\,r_t<0]}\sqrt{252}$
+- **Ledoit–Wolf Covariance** $\Sigma = 252\,\text{LW}(r_t)$
+- **Black–Litterman Posterior**
+  \[\mu = ( (\tau\Sigma)^{-1} + P^\top\Omega^{-1}P )^{-1}( (\tau\Sigma)^{-1}\pi + P^\top\Omega^{-1}Q )\]
+- **Risk Parity** – weights scaled so $w_i(\Sigma w)_i$ are equal
+- **Min–Max Optimisation**
+  \[w^* = \arg\max_w\; w^\top\mu - \gamma(1+\delta)w^\top\Sigma w\]
+- **Historical VaR** $\displaystyle \text{VaR}_\alpha=-\text{quantile}_{1-\alpha}(r_t)$
+- **Conditional VaR** $\displaystyle \text{CVaR}_\alpha=-\mathbb{E}[r_t\,|\,r_t\le-\text{VaR}_\alpha]$
 
 ## Strategy Reference
 
-The table below lists the data sources used by each strategy and how often each portfolio is rebalanced.
+Data sources and rebalance frequency for each strategy are shown below.
 
-| Strategy | URL(s) | Rebalance Period | One-line description |
-|---------|-------|------------------|---------------------|
-| Congressional-Trading Aggregate | https://www.quiverquant.com/congresstrading/ | Weekly (Mon) | Hold the 20 stocks with the largest net congressional dollar-buys over the last 30 days. |
-| "Follow-the-Leader" Politician Sleeves | Meuser https://www.quiverquant.com/congresstrading/politician/Daniel%20Meuser-M001204 \| Pelosi https://www.quiverquant.com/congresstrading/politician/Nancy%20Pelosi-P000197 \| Capito https://www.quiverquant.com/congresstrading/politician/Shelley%20Moore%20Capito-C001047 | Monthly (first Mon) | Each sleeve mimics the politician’s entire set of disclosed trades. |
-| DC Insider Score Tilt | https://www.quiverquant.com/scores/dcinsider | Weekly (Mon) | Go long the 30 highest "DC Insider"-scored stocks. |
-| Government-Contracts Momentum | https://www.quiverquant.com/sources/govcontracts | Monthly (first trading day) | Own every firm (max 25) awarded ≥ $50 M in new U.S. federal contracts in the prior month. |
-| Corporate Insider Buying Pulse | https://www.quiverquant.com/insiders/ | Weekly (Mon) | Hold the 25 names with the largest 30-day net executive dollar-buying. |
-| Wikipedia Attention Surge | https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/all-agents/{Page_Title}/daily/{start}/{end} | Weekly (Mon) | Long the 10 S&P 1500 stocks showing the biggest spike in Wikipedia page views (7 d vs 30 d z-score). |
-| Wall Street Bets Buzz | Reddit API (r/wallstreetbets) | Weekly (Mon) | Go long the 15 symbols with the fastest 7-day growth in subreddit mentions (≥ 500 baseline). |
-| App Reviews Hype Score | https://www.quiverquant.com/sources/appratings | Weekly (Mon) | Own the 20 stocks with the largest week-over-week rise in Quiver’s app-review “hype score.” |
-| Google Trends + News Sentiment | https://www.quiverquant.com/googletrends/ | Monthly (first trading day) | Hold the 30 tickers with the biggest month-over-month search-interest jump and positive news sentiment. |
+| Strategy | Source | Period | Description |
+|---------|--------|--------|-------------|
+| Congressional-Trading Aggregate | Quiver congress trading | Weekly (Mon) | Top 20 names by net congressional dollar buys over the last month |
+| "Follow-the-Leader" Politician Sleeves | Individual congress trading pages | Monthly (first Mon) | Replicate trades for specific politicians |
+| DC Insider Score Tilt | Quiver DC Insider scores | Weekly (Mon) | Long the 30 highest insider-score stocks |
+| Government-Contracts Momentum | Quiver gov contracts | Monthly (first trading day) | Own firms with ≥\$50M in new federal contracts last month |
+| Corporate Insider Buying Pulse | Quiver insider filings | Weekly (Mon) | Long the 25 tickers with strongest executive buying |
+| Wikipedia Attention Surge | Wikimedia page views | Weekly (Mon) | Long the 10 S&P1500 stocks with the biggest page-view spike |
+| Wall Street Bets Buzz | Reddit API | Weekly (Mon) | Long the 15 symbols with the fastest rise in subreddit mentions |
+| App Reviews Hype Score | Quiver app ratings | Weekly (Mon) | Long the 20 names with the largest jump in app-review "hype" |
+| Google Trends + News Sentiment | Quiver Google Trends | Monthly (first trading day) | Long 30 tickers with rising search interest and positive news |
+| Sector Risk-Parity Momentum | Yahoo Finance | Weekly (Fri) | Rotate among sector ETFs using risk-parity weights |
+| Leveraged Sector Momentum | Yahoo Finance | Weekly (Fri) | Momentum rotation among leveraged sector ETFs |
+| Volatility-Scaled Momentum | Yahoo Finance | Weekly (Fri) | Rank stocks by 12‑month return scaled by volatility |
+| Upgrade Momentum | Quiver analyst ratings | Weekly (Mon) | Tilt toward names with a surge in upgrades |
+| Biotech Binary Event Basket | Various filings | Monthly | Basket of biotech stocks ahead of binary catalysts |
+| Lobbying Growth | Quiver lobbying data | Monthly | Long the 20 tickers with the largest quarter‑over‑quarter lobbying spend growth |
 
+## Installation
 
-| Sector Risk-Parity Momentum | Yahoo Finance | Weekly (Fri) | Rotate among S&P 500 sector ETFs using risk-parity weights. |
-| Leveraged Sector Momentum | Yahoo Finance | Weekly (Fri) | Momentum rotation among leveraged sector ETFs. |
-| Volatility-Scaled Momentum | Yahoo Finance | Weekly (Fri) | Rank stocks by twelve-month return scaled by volatility. |
-| Upgrade Momentum | Quiver Analyst Ratings | Weekly (Mon) | Tilt towards names with a surge in analyst upgrades. |
-| Biotech Binary Event Basket | Various filings | Monthly | Basket of biotech stocks ahead of binary catalysts. |
-| Lobbying Growth (example) | Quiver Lobbying | Monthly | Placeholder using companies with strong lobbying growth. |
-## Deployment on Ubuntu
-
-Below is a step-by-step guide to running the system on an Ubuntu server. These steps assume a fresh VM with Python 3.12 installed.
-
-1. **Install system packages**
-   ```bash
-   sudo apt update && sudo apt install -y git python3-venv
-   ```
-2. **Clone the repository**
+1. Clone the repository
    ```bash
    git clone <repo_url>
    cd Portfolio_Allocation_System
    ```
-3. **Create and activate a virtual environment**
+2. Create and activate a virtual environment
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    ```
-4. **Install Python requirements**
+3. Install Python dependencies
    ```bash
    pip install -r requirements.txt
    ```
-5. **Set environment variables**
-   Create a `.env` file or export variables in your shell:
-   ```bash
-   export ALPACA_API_KEY="<key>"
-   export ALPACA_API_SECRET="<secret>"
-   export MONGO_URI="mongodb://localhost:27017"
-   export DB_NAME="quant_fund"
-   export QUIVER_RATE_SEC="1.1"
-   ```
-   If using Alpaca paper trading ensure `ALPACA_BASE_URL=https://paper-api.alpaca.markets`.
 
-6. **Start MongoDB** (and optionally Redis)
-   ```bash
-   docker run -d --name mongo -p 27017:27017 mongo:7
-   ```
+Set `ALPACA_API_KEY`, `ALPACA_API_SECRET`, `MONGO_URI` and other variables in a `.env` file or the shell before running.
 
-7. **Run scrapers** to populate the database. Each scraper can be executed manually or via cron:
-   ```bash
-   python -m scrapers.politician
-   python -m scrapers.lobbying
-   python -m scrapers.wiki
-   python -m scrapers.dc_insider
-   python -m scrapers.gov_contracts
-   ```
-8. **Launch the server**
-   ```bash
-   python start.py > logs/app.log 2>&1 &
-   ```
-   Visit `http://your-server:8000/docs` to confirm it is running. All requests
-   are CORS enabled so a future front end can consume the API directly.
+## Quickstart
 
-9. *(Optional)* **Expose with Cloudflare Tunnel**
-   ```bash
-   cloudflared tunnel --url http://localhost:8000
-   ```
-   This hides your IP while still allowing secure access through a public URL.
+Start the API with Uvicorn and launch the scheduler:
 
-10. **Check logs for errors**
-    - `logs/app.log` collects both API and scheduler messages
-    - Use `tail -f logs/app.log` to monitor activity in real time
+```bash
+python start.py
+```
 
-Databases and required collections are created automatically on first run.
-
-11. **Stopping services**
-    Use `pkill -f uvicorn` and `pkill -f start.py` or stop the processes via systemd if you create service files.
-
-### Potential Pitfalls
-- Ensure system time is synced (use `timedatectl status`). Time drift can break signing for Alpaca requests.
-- The Alpaca account must have sufficient buying power and permissions for the target assets.
-- Network hiccups or API rate limits may cause scrapers to retry slowly; monitor logs for repeated warnings.
-- MongoDB volume can grow quickly. Set up periodic backups or prune old scrapings if disk space is limited.
-- If environment variables are missing the application may start but fail silently when calling external APIs.
-
-The `AlpacaGateway` in `execution/gateway.py` is functional but minimal. Orders are submitted via Alpaca's REST API with basic notional and volume checks. Review this code and set appropriate API keys before using real money.
+APScheduler jobs rebalance portfolios according to the active strategies.  REST endpoints under `/docs` allow manual portfolio management and data collection.

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,7 @@ transformers>=4.41.1
 sentencepiece>=0.2.0
 rich>=13.7.1
 mypy>=1.8.0
+
+pydantic>=2.5.0
+pyarrow>=14.0.2
+sentry-sdk>=2.0.0

--- a/strategies/lobbying_growth.py
+++ b/strategies/lobbying_growth.py
@@ -1,6 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
 from core.equity import EquityPortfolio
+from database import lobby_coll
+
 
 class LobbyingGrowthStrategy:
-    async def build(self, pf: EquityPortfolio):
-        pf.set_weights({"AAPL":1.0})
+    """Long companies with the largest increase in lobbying spend."""
+
+    def __init__(self, top_n: int = 20) -> None:
+        self.top_n = top_n
+
+    def _fetch(self) -> pd.DataFrame:
+        docs = list(lobby_coll.find())
+        if not docs:
+            return pd.DataFrame()
+        df = pd.DataFrame(docs)
+        df["amount"] = (
+            df["amount"].str.replace("$", "").str.replace(",", "").astype(float)
+        )
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df = df.dropna(subset=["date", "amount"])
+        latest = df["date"].max()
+        cutoff = latest - pd.Timedelta(days=60)
+        return df[df["date"] >= cutoff]
+
+    def _rank(self, df: pd.DataFrame) -> pd.Series:
+        if df.empty:
+            return pd.Series(dtype=float)
+        recent = df[df["date"] >= df["date"].max() - pd.Timedelta(days=30)]
+        prior = df[df["date"] < df["date"].max() - pd.Timedelta(days=30)]
+        last_sum = recent.groupby("ticker")["amount"].sum()
+        prev_sum = prior.groupby("ticker")["amount"].sum()
+        growth = (last_sum - prev_sum).div(prev_sum.replace(0, pd.NA))
+        return growth.dropna().sort_values(ascending=False)
+
+    async def build(self, pf: EquityPortfolio) -> None:
+        df = self._fetch()
+        ranks = self._rank(df).head(self.top_n)
+        if ranks.empty:
+            return
+        w = {sym: 1 / len(ranks) for sym in ranks.index}
+        pf.set_weights(w)
         await pf.rebalance()

--- a/tests/test_lobbying_growth.py
+++ b/tests/test_lobbying_growth.py
@@ -1,0 +1,56 @@
+import os
+
+os.environ["MONGO_URI"] = "mongomock://localhost"
+
+import asyncio
+import datetime as dt
+
+from database import lobby_coll
+from strategies.lobbying_growth import LobbyingGrowthStrategy
+
+
+class DummyPF:
+    def __init__(self):
+        self.weights = {}
+
+    def set_weights(self, w):
+        self.weights = w
+
+    async def rebalance(self):
+        pass
+
+
+def seed_data():
+    lobby_coll.delete_many({})
+    today = dt.date.today()
+    for i in range(40):
+        amt_a = "$20000" if i < 20 else "$10000"
+        lobby_coll.insert_one(
+            {
+                "ticker": "AAA",
+                "client": "X",
+                "amount": amt_a,
+                "date": (today - dt.timedelta(days=i)).strftime("%m/%d/%Y"),
+            }
+        )
+        lobby_coll.insert_one(
+            {
+                "ticker": "BBB",
+                "client": "Y",
+                "amount": "$10000",
+                "date": (today - dt.timedelta(days=i)).strftime("%m/%d/%Y"),
+            }
+        )
+
+
+async def _run():
+    seed_data()
+    strat = LobbyingGrowthStrategy(top_n=1)
+    pf = DummyPF()
+    await strat.build(pf)
+    return pf.weights
+
+
+def test_growth_weights():
+    weights = asyncio.run(_run())
+    assert weights == {"AAA": 1.0}


### PR DESCRIPTION
## Summary
- overhaul the README with all strategies and model equations
- implement real logic for `LobbyingGrowthStrategy`
- add a unit test for the lobbying strategy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686c1b2836c08323a990a163f6b46e28