### PR TITLE
Ensure allocator works with short histories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The Portfolio Allocation System runs a suite of alternative‑data strategies an
 - **Alpaca** gateway with paper/live detection
 - **Postgres + DuckDB** data store
 - **Prometheus metrics** and structured logging
+- **Correlation endpoint** to compare portfolio relationships
+- **Sector exposure endpoint** for portfolio sector breakdowns
 
 ## Usage
 
@@ -95,5 +97,5 @@ The Portfolio Allocation System runs a suite of alternative‑data strategies an
 
 ## Allocation Logic
 
-Weekly returns for each portfolio are cleaned with a z‑score filter and summarised over the last twelve weeks. A Ledoit–Wolf estimator produces the covariance matrix and mean returns are treated as expected returns. The tangency portfolio weights are computed from these inputs, scaled to an 8% annual volatility target and clipped to the configured minimum and maximum. Small changes under 0.5 percentage points are ignored to reduce turnover. If the resulting volatility is unrealistic, the previous weights are reused. Every step is logged for audit purposes.
+Weekly returns are cleaned with a z-score filter and a rolling window of up to 36 weeks is used. When fewer than four weeks of data exist the allocator simply assigns equal weights. Once at least four weeks are available, all history up to 36 weeks feeds the Ledoit–Wolf covariance and mean-return estimates. The positive part of ``Σ⁻¹μ`` gives the long-only max‑Sharpe mix while ``Σ⁻¹(μ − r_f)`` yields the tangency portfolio. This unit-sum portfolio is scaled to an 11% volatility target (clamped between 10–12%) and clipped to the configured bounds. Tiny changes below 0.5 percentage points are skipped, extreme volatility reuses the previous allocation, and portfolio correlations and sector exposures are provided for the UI.
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -4,7 +4,12 @@ from .tracking import update_all_metrics, update_all_ticker_returns
 from .robust import minmax_portfolio
 from .account import record_account
 from .allocation_engine import compute_weights
-from .utils import portfolio_metrics
+from .utils import (
+    portfolio_metrics,
+    portfolio_correlations,
+    sector_exposures,
+    ticker_sector,
+)
 
 __all__ = [
     "record_snapshot",
@@ -15,4 +20,7 @@ __all__ = [
     "record_account",
     "compute_weights",
     "portfolio_metrics",
+    "portfolio_correlations",
+    "sector_exposures",
+    "ticker_sector",
 ]


### PR DESCRIPTION
## Summary
- support <36 week lookbacks in `compute_weights`
- log volatility anomalies and reuse prior weights
- document `/correlations` endpoint and clarify allocator details
- improve allocator and add sector exposure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875aac707008323b281abc67da15311