### PR TITLE
Fix bootstrap imports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ The Portfolio Allocation System runs a suite of alternative‑data strategies an
    python -m service.start
    ```
    The startup script now runs each scraper in sequence and logs a checklist
-   once data is loaded.
+   once data is loaded. Failed scrapers print their output so you can debug
+   issues, and the systemd unit sets `PYTHONPATH` so imports resolve.
+   If `wsb_mentions` fails with "Universe is empty" run the universe builder
+   first:
+   ```bash
+   python -m scrapers.universe --refresh-universe
+   sudo bash scripts/bootstrap.sh
+   ```
 5. Install the optional test dependencies and run the unit tests
    ```bash
    pip install -r deploy/requirements-test.txt

--- a/service/start.py
+++ b/service/start.py
@@ -47,7 +47,11 @@ async def run_startup_scrapers() -> None:
     """Run all data scrapers sequentially and log progress."""
     for name, func in SCRAPERS:
         try:
-            data = await func() if asyncio.iscoroutinefunction(func) else func()
+            result = func()
+            if asyncio.iscoroutine(result):
+                data = await result
+            else:
+                data = result
             rows = cols = 0
             if isinstance(data, pd.DataFrame):
                 rows, cols = data.shape


### PR DESCRIPTION
## Summary
- avoid unawaited coroutine in startup scraper loop
- log scraper output in bootstrap and set PYTHONPATH for systemd
- clarify debugging instructions for wsb_mentions failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68791f86d42483239d3c8ae88dd5f870