### PR TITLE
Fix expire timezone check in scraper

### DIFF
--- a/infra/smart_scraper.py
+++ b/infra/smart_scraper.py
@@ -35,6 +35,10 @@ async def get(url: str, retries: int = 3) -> str:
     doc = cache.find_one({"key": key})
     if doc:
         expire = doc.get("expire")
+        if expire is not None:
+            # normalise to UTC if timezone info missing
+            if expire.tzinfo is None:
+                expire = expire.replace(tzinfo=dt.timezone.utc)
         if expire is not None and expire > dt.datetime.now(dt.timezone.utc):
             return doc["payload"]
 

--- a/scrapers/finviz_fundamentals.py
+++ b/scrapers/finviz_fundamentals.py
@@ -3,10 +3,13 @@ from bs4 import BeautifulSoup, Tag
 import requests
 
 from database import init_db
+from service.logger import get_logger
 
 
 def fetch_fundamentals(symbol: str) -> Dict[str, Optional[float]]:
     """Fetch key fundamental metrics from Finviz."""
+    log = get_logger(__name__)
+    log.info(f"fetch_fundamentals start symbol={symbol}")
     init_db()
     url = f"https://finviz.com/quote.ashx?t={symbol}&p=d&ty=ea"
     r = requests.get(url, timeout=30)
@@ -24,6 +27,7 @@ def fetch_fundamentals(symbol: str) -> Dict[str, Optional[float]]:
                 vals[key] = float(val)
             except ValueError:
                 continue
+    log.info("fetch_fundamentals complete")
     return {
         "piotroski": vals.get("Piotroski F-Score"),
         "altman": vals.get("Altman Z-Score"),

--- a/scrapers/google_trends.py
+++ b/scrapers/google_trends.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import json
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
+from playwright.async_api import async_playwright
 
 from service.config import QUIVER_RATE_SEC
 from infra.rate_limiter import DynamicRateLimiter
@@ -21,35 +23,48 @@ async def fetch_google_trends() -> List[dict]:
     """Scrape Google Trends scores from QuiverQuant."""
     log.info("fetch_google_trends start")
     init_db()
-    url = "https://www.quiverquant.com/googletrends/"
+    api_url = "https://www.quiverquant.com/data/googletrends"
+    html_url = "https://www.quiverquant.com/googletrends/"
     with scrape_latency.labels("google_trends").time():
         try:
             async with rate:
-                html = await scrape_get(url)
+                json_text = await scrape_get(api_url)
+            rows = json.loads(json_text)
         except Exception as exc:
             scrape_errors.labels("google_trends").inc()
-            log.warning(f"fetch_google_trends failed: {exc}")
-            raise
-    soup = BeautifulSoup(html, "html.parser")
-    table = cast(Optional[Tag], soup.find("table"))
+            log.warning(f"google_trends API failed: {exc}; using headless browser")
+            try:
+                async with async_playwright() as pw:
+                    browser = await pw.chromium.launch(headless=True)
+                    page = await browser.new_page()
+                    await page.goto(html_url)
+                    html = await page.content()
+                    await browser.close()
+                soup = BeautifulSoup(html, "html.parser")
+                table = cast(Optional[Tag], soup.find("table"))
+                if table is None:
+                    log.warning("google_trends: no <table> found – site layout may have changed")
+                    append_snapshot("google_trends", [])
+                    return []
+                rows = []
+                for row in cast(List[Tag], table.find_all("tr"))[1:]:
+                    cells = [c.get_text(strip=True) for c in row.find_all("td")]
+                    if len(cells) >= 3:
+                        rows.append({"ticker": cells[0], "score": cells[1], "date": cells[2]})
+            except Exception as exc2:
+                scrape_errors.labels("google_trends").inc()
+                log.warning(f"google_trends fallback failed: {exc2}")
+                raise
     data: List[dict] = []
     now = dt.datetime.now(dt.timezone.utc)
-    if table:
-        for row in cast(List[Tag], table.find_all("tr"))[1:]:
-            cells = [c.get_text(strip=True) for c in row.find_all("td")]
-            if len(cells) >= 3:
-                item = {
-                    "ticker": cells[0],
-                    "score": cells[1],
-                    "date": cells[2],
-                    "_retrieved": now,
-                }
-                data.append(item)
-                trends_coll.update_one(
-                    {"ticker": item["ticker"], "date": item["date"]},
-                    {"$set": item},
-                    upsert=True,
-                )
+    for item in rows:
+        item["_retrieved"] = now
+        data.append(item)
+        trends_coll.update_one(
+            {"ticker": item["ticker"], "date": item["date"]},
+            {"$set": item},
+            upsert=True,
+        )
     append_snapshot("google_trends", data)
     log.info(f"fetched {len(data)} google trend rows")
     return data

--- a/scrapers/google_trends.py
+++ b/scrapers/google_trends.py
@@ -3,7 +3,10 @@ import json
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
-from playwright.async_api import async_playwright
+try:
+    from playwright.async_api import async_playwright
+except Exception:  # noqa: S110
+    async_playwright = None
 
 from service.config import QUIVER_RATE_SEC
 from infra.rate_limiter import DynamicRateLimiter
@@ -34,6 +37,8 @@ async def fetch_google_trends() -> List[dict]:
             scrape_errors.labels("google_trends").inc()
             log.warning(f"google_trends API failed: {exc}; using headless browser")
             try:
+                if async_playwright is None:
+                    raise RuntimeError("playwright not installed")
                 async with async_playwright() as pw:
                     browser = await pw.chromium.launch(headless=True)
                     page = await browser.new_page()

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -3,7 +3,10 @@ import json
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
-from playwright.async_api import async_playwright
+try:
+    from playwright.async_api import async_playwright
+except Exception:  # noqa: S110
+    async_playwright = None
 from service.config import QUIVER_RATE_SEC
 from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
@@ -34,6 +37,8 @@ async def fetch_lobbying_data() -> List[dict]:
             scrape_errors.labels("lobbying").inc()
             log.warning(f"lobbying API failed: {exc}; using headless browser")
             try:
+                if async_playwright is None:
+                    raise RuntimeError("playwright not installed")
                 async with async_playwright() as pw:
                     browser = await pw.chromium.launch(headless=True)
                     page = await browser.new_page()

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import json
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
+from playwright.async_api import async_playwright
 from service.config import QUIVER_RATE_SEC
 from infra.rate_limiter import DynamicRateLimiter
 from infra.smart_scraper import get as scrape_get
@@ -21,40 +23,57 @@ async def fetch_lobbying_data() -> List[dict]:
     """Scrape corporate lobbying spending from QuiverQuant."""
     log.info("fetch_lobbying_data start")
     init_db()
-    url = "https://www.quiverquant.com/lobbying/"
+    api_url = "https://www.quiverquant.com/data/lobbying"
+    html_url = "https://www.quiverquant.com/lobbying/"
     with scrape_latency.labels("lobbying").time():
         try:
             async with rate:
-                html = await scrape_get(url)
+                json_text = await scrape_get(api_url)
+            rows = json.loads(json_text)
         except Exception as exc:
             scrape_errors.labels("lobbying").inc()
-            log.warning(f"fetch_lobbying_data failed: {exc}")
-            raise
-    soup = BeautifulSoup(html, "html.parser")
-    table = cast(Optional[Tag], soup.find("table"))
-    if table is None:
-        log.warning("lobbying: no <table> found – site layout may have changed")
-        append_snapshot("lobbying", [])
-        return []
+            log.warning(f"lobbying API failed: {exc}; using headless browser")
+            try:
+                async with async_playwright() as pw:
+                    browser = await pw.chromium.launch(headless=True)
+                    page = await browser.new_page()
+                    await page.goto(html_url)
+                    html = await page.content()
+                    await browser.close()
+                soup = BeautifulSoup(html, "html.parser")
+                table = cast(Optional[Tag], soup.find("table"))
+                if table is None:
+                    log.warning(
+                        "lobbying: no <table> found – site layout may have changed"
+                    )
+                    append_snapshot("lobbying", [])
+                    return []
+                rows = []
+                for row in cast(List[Tag], table.find_all("tr"))[1:]:
+                    cells = [c.get_text(strip=True) for c in row.find_all("td")]
+                    if len(cells) >= 4:
+                        rows.append(
+                            {
+                                "ticker": cells[0],
+                                "client": cells[1],
+                                "amount": cells[2],
+                                "date": cells[3],
+                            }
+                        )
+            except Exception as exc2:
+                scrape_errors.labels("lobbying").inc()
+                log.warning(f"lobbying fallback failed: {exc2}")
+                raise
     data: List[dict] = []
     now = dt.datetime.now(dt.timezone.utc)
-    if table:
-        for row in cast(List[Tag], table.find_all("tr"))[1:]:
-            cells = [c.get_text(strip=True) for c in row.find_all("td")]
-            if len(cells) >= 4:
-                item = {
-                    "ticker": cells[0],
-                    "client": cells[1],
-                    "amount": cells[2],
-                    "date": cells[3],
-                    "_retrieved": now,
-                }
-                data.append(item)
-                lobby_coll.update_one(
-                    {"ticker": item["ticker"], "date": item["date"]},
-                    {"$set": item},
-                    upsert=True,
-                )
+    for item in rows:
+        item["_retrieved"] = now
+        data.append(item)
+        lobby_coll.update_one(
+            {"ticker": item["ticker"], "date": item["date"]},
+            {"$set": item},
+            upsert=True,
+        )
     append_snapshot("lobbying", data)
     log.info(f"fetched {len(data)} lobbying rows")
     return data

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -32,6 +32,10 @@ async def fetch_lobbying_data() -> List[dict]:
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))
+    if table is None:
+        log.warning("lobbying: no <table> found – site layout may have changed")
+        append_snapshot("lobbying", [])
+        return []
     data: List[dict] = []
     now = dt.datetime.now(dt.timezone.utc)
     if table:

--- a/scrapers/universe.py
+++ b/scrapers/universe.py
@@ -10,9 +10,11 @@ import requests
 
 from database import init_db, universe_coll
 from io import StringIO
+from service.logger import get_logger
 
 DATA_DIR = Path("cache") / "universes"
 DATA_DIR.mkdir(parents=True, exist_ok=True)
+log = get_logger(__name__)
 
 SP500_URL = "https://datahub.io/core/s-and-p-500-companies/_r/-/data/constituents.csv"
 SP400_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_400_companies"
@@ -51,6 +53,7 @@ def _store_universe(tickers: List[str], index_name: str) -> None:
 
 def download_sp500(path: Path | None = None) -> Path:
     """Download S&P 500 constituents to CSV and database."""
+    log.info("download_sp500 start")
     path = path or DATA_DIR / "sp500.csv"
     r = requests.get(SP500_URL, timeout=30)
     r.raise_for_status()
@@ -58,24 +61,29 @@ def download_sp500(path: Path | None = None) -> Path:
     tickers = df[df.columns[0]].astype(str).str.upper().tolist()
     pd.DataFrame(tickers, columns=["symbol"]).to_csv(path, index=False)
     _store_universe(tickers, "S&P500")
+    log.info(f"download_sp500 wrote {len(tickers)} symbols")
     return path
 
 
 def download_sp400(path: Path | None = None) -> Path:
     """Download S&P 400 constituents to CSV."""
+    log.info("download_sp400 start")
     path = path or DATA_DIR / "sp400.csv"
     tickers = _tickers_from_wiki(SP400_URL)
     pd.DataFrame(sorted(tickers), columns=["symbol"]).to_csv(path, index=False)
     _store_universe(list(tickers), "S&P400")
+    log.info(f"download_sp400 wrote {len(tickers)} symbols")
     return path
 
 
 def download_russell2000(path: Path | None = None) -> Path:
     """Download Russell 2000 constituents to CSV."""
+    log.info("download_russell2000 start")
     path = path or DATA_DIR / "russell2000.csv"
     tickers = _tickers_from_wiki(R2000_URL)
     pd.DataFrame(sorted(tickers), columns=["symbol"]).to_csv(path, index=False)
     _store_universe(list(tickers), "Russell2000")
+    log.info(f"download_russell2000 wrote {len(tickers)} symbols")
     return path
 
 

--- a/service/start.py
+++ b/service/start.py
@@ -8,6 +8,9 @@ from scrapers.universe import (
     download_sp500,
     download_sp400,
     download_russell2000,
+    load_sp500,
+    load_sp400,
+    load_russell2000,
 )
 from scrapers.politician import fetch_politician_trades
 from scrapers.lobbying import fetch_lobbying_data
@@ -86,6 +89,9 @@ def validate_startup() -> None:
     download_sp500()
     download_sp400()
     download_russell2000()
+    universe = set(load_sp500()) | set(load_sp400()) | set(load_russell2000())
+    if len(universe) < 2000:
+        log.warning(f"universe size {len(universe)} < 2000")
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -14,6 +14,12 @@ async def test_run_scrapers(monkeypatch):
         return [{"ok": 1}]
 
     monkeypatch.setattr(boot, "init_db", lambda: calls.append("init"))
+    monkeypatch.setattr(boot, "download_sp500", lambda: calls.append("u"))
+    monkeypatch.setattr(boot, "download_sp400", lambda: calls.append("u"))
+    monkeypatch.setattr(boot, "download_russell2000", lambda: calls.append("u"))
+    monkeypatch.setattr(boot, "load_sp500", lambda: ["AAPL"])
+    monkeypatch.setattr(boot, "load_sp400", lambda: ["MSFT"])
+    monkeypatch.setattr(boot, "load_russell2000", lambda: ["X"] * 2000)
     monkeypatch.setattr(boot, "fetch_politician_trades", fake)
     monkeypatch.setattr(boot, "fetch_lobbying_data", fake)
     monkeypatch.setattr(boot, "fetch_trending_wiki_views", fake)

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -11,6 +11,7 @@ import scrapers.wiki as wiki
 import scrapers.analyst_ratings as ar
 import scrapers.universe as univ
 import scrapers.sp500_index as spx
+import scrapers.google_trends as gt
 
 
 async def _fake_get(*_args, **_kw):
@@ -119,3 +120,43 @@ def test_helpers(monkeypatch, tmp_path):
     data2 = pd.read_csv(p2)
     assert data2.iloc[0][0] == "MSFT"
     print(data2.iloc[0].to_dict())
+
+
+@pytest.mark.asyncio
+async def test_google_trends_json(monkeypatch):
+    monkeypatch.setattr(gt, "trends_coll", mock.Mock())
+
+    async def fake_get(url):
+        return '[{"ticker": "AAPL", "score": "1", "date": "2024-01-01"}]'
+
+    class DummyRate:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+    monkeypatch.setattr(gt, "scrape_get", fake_get)
+    monkeypatch.setattr(gt, "rate", DummyRate())
+    rows = await gt.fetch_google_trends()
+    assert rows and rows[0]["ticker"] == "AAPL"
+
+
+@pytest.mark.asyncio
+async def test_lobbying_no_table(monkeypatch):
+    monkeypatch.setattr(lb, "lobby_coll", mock.Mock())
+
+    async def fake_get(*_a, **_k):
+        return "<html></html>"
+
+    class DummyRate:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+    monkeypatch.setattr(lb, "scrape_get", fake_get)
+    monkeypatch.setattr(lb, "rate", DummyRate())
+    rows = await lb.fetch_lobbying_data()
+    assert rows == []

--- a/tests/test_smart_scraper.py
+++ b/tests/test_smart_scraper.py
@@ -1,0 +1,19 @@
+import datetime as dt
+import hashlib
+import pytest
+
+from infra import smart_scraper
+from database import InMemoryCollection
+
+
+@pytest.mark.asyncio
+async def test_get_handles_naive_expire(monkeypatch):
+    url = 'http://example.com'
+    key = hashlib.md5(url.encode()).hexdigest()
+    mem = InMemoryCollection()
+    mem.replace_one({'key': key}, {'key': key, 'payload': 'cached', 'expire': dt.datetime.now() + dt.timedelta(seconds=60)}, upsert=True)
+    monkeypatch.setattr(smart_scraper, 'cache', mem)
+    monkeypatch.setattr(smart_scraper.requests, 'get', lambda *a, **k: (_ for _ in ()).throw(AssertionError('network')))
+
+    result = await smart_scraper.get(url)
+    assert result == 'cached'


### PR DESCRIPTION
## Summary
- fix naive timezone comparison in `infra.smart_scraper`
- add a regression test covering naive `expire` values
- fetch Google Trends via API with a Playwright fallback
- guard lobby scraper from missing tables
- run universe scrapers before other startup scrapers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879931367988323a7c590c4125f06fb