### PR TITLE
Implement Benzinga analyst scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The Portfolio Allocation System runs a suite of alternative‑data strategies an
 | Government-Contracts Momentum | Quiver gov contracts | Monthly | Own firms with \$50M+ new federal contracts |
 | Corporate Insider Buying Pulse | Quiver insider filings | Weekly | Long 25 tickers with strongest buying |
 | Wikipedia Attention Surge | Wikimedia page views | Weekly | Long top 10 names by page‑view jump |
-| Wall Street Bets Buzz | Reddit API | Weekly | Long 15 tickers with fastest rise in mentions |
+| Wall Street Bets Buzz | ApeWisdom API | Weekly | Long 15 tickers with fastest rise in mentions |
 | App Reviews Hype Score | Quiver app ratings | Weekly | Long 20 names with largest hype increase |
 | Google Trends + News Sentiment | Quiver Google Trends + Finviz news | Monthly | Long 30 tickers with rising search interest and good news |
 | Sector Risk-Parity Momentum | Yahoo Finance | Weekly | Rotate sector ETFs using risk‑parity weights |
 | Leveraged Sector Momentum | Yahoo Finance | Weekly | Momentum rotation among leveraged sector ETFs |
 | Volatility-Scaled Momentum | Yahoo Finance | Weekly | Rank stocks by 12‑month return scaled by volatility |
-| Upgrade Momentum | Finviz analyst revisions | Weekly | Tilt toward names with improving analyst revisions |
+| Upgrade Momentum | Benzinga upgrades | Weekly | Tilt toward names with improving analyst revisions |
 | Small Cap Momentum | Various filings | Monthly | Trade small caps before catalysts, exit after 50% gain or 3 months |
 | Sector-Neutral Mini-Portfolios | Composite screener | Quarterly | Equal-weight top value names by sector |
 | Micro-Small Composite Leaders | Composite screener | Monthly | Value and momentum leaders in micro/small caps |
@@ -79,7 +79,7 @@ The Portfolio Allocation System runs a suite of alternative‑data strategies an
 | Google Trends | https://www.quiverquant.com/googletrends/ |
 | Insider Buying | https://www.quiverquant.com/insiders/ |
 | Wikipedia Views | https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/all-agents/{Page_Title}/daily/{start}/{end} |
-| Analyst Ratings | https://finviz.com/quote.ashx?t=AAPL&ty=c&p=d&b=1 |
+| Analyst Ratings (Playwright) | https://www.benzinga.com/analyst-ratings/upgrades |
 | Finviz Fundamentals | https://finviz.com/quote.ashx?t=AAPL&p=d&ty=ea |
 | Finviz Stock News | https://finviz.com/news.ashx?v=3 |
 | S&P 500 Index | https://finance.yahoo.com/quote/%5EGSPC |

--- a/analytics/AGENTS.md
+++ b/analytics/AGENTS.md
@@ -20,3 +20,5 @@ functions to build portfolios. Recent commits introduced a tangency allocator th
 - When signal quality is uncertain, favour volatility scaling or equal-weight fallbacks for stability.
 - Clip extreme weekly returns before estimating covariance and revert to the
   previous allocation if the computed volatility is clearly abnormal.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/backtest/AGENTS.md
+++ b/backtest/AGENTS.md
@@ -7,3 +7,5 @@ It relies on scrapers in `scrapers/` to provide price and event data and uses
 `analytics/` modules to evaluate performance. The July 2025 update added
 support for running the full strategy suite with mocked market data so tests
 can verify portfolio construction without downloading large datasets.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -8,3 +8,5 @@ Core data classes representing portfolios and assets.
 These classes are used by strategies and analytics across the project.
 Recent commits introduced chunked return fetching and portfolio tracking for
 large universes which rely heavily on these base dataclasses.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/database/AGENTS.md
+++ b/database/AGENTS.md
@@ -12,3 +12,5 @@ The helpers are used by scrapers to store raw data and by strategies to fetch
 historic metrics. Startup calls `init_db()` here to create tables. When
 Postgres is unavailable the code falls back to an in-memory DuckDB database so
 all components keep functioning.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,0 +1,10 @@
+# Folder Overview
+
+Deployment configuration and requirement files.
+- `Dockerfile` builds the production image.
+- `requirements.txt` lists runtime dependencies.
+- `requirements-test.txt` lists packages needed only for tests.
+- `mypy.ini` and `mkdocs.yml` store type-checking and docs config.
+
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/deploy/requirements-test.txt
+++ b/deploy/requirements-test.txt
@@ -28,3 +28,4 @@ types-requests>=2.32
 scipy>=1.13.1
 html5lib>=1.1
 lxml>=5.2.1
+playwright>=1.42

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -40,3 +40,4 @@ pydantic-settings>=2.0.3
 Deprecated>=1.2.13
 html5lib>=1.1
 lxml>=5.2.1
+playwright>=1.42

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -10,3 +10,5 @@ implementation details. Recent documentation updates list every data source URL,
 explain how scrapers run automatically at startup, describe the
 `index_name` field in `ticker_scores` and document metrics like
 `weekly_vol`, `weekly_sortino`, `atr_14d` and `rsi_14d`.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/execution/AGENTS.md
+++ b/execution/AGENTS.md
@@ -7,3 +7,5 @@ Broker connectivity helpers.
 Strategies construct trades through these utilities after computing weights.
 The gateway checks for paper vs live trading endpoints and exposes a
 `allow_live` flag so unit tests avoid real orders.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -9,3 +9,5 @@ Supporting infrastructure used across the system.
 These tools are imported by `scrapers/` and monitored via `observability/`.
 The July 2025 release introduced a threaded scraper using `requests` to better
 handle network proxies.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -6,3 +6,5 @@ Ledger utilities for transaction records.
 Trade data is ingested from the `execution/` layer and summarised by
 `analytics/` tools. Recent updates added DuckDB snapshots so ledger histories
 survive restarts when Postgres is unavailable.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/metrics/AGENTS.md
+++ b/metrics/AGENTS.md
@@ -6,3 +6,5 @@ Shared Prometheus metrics setup.
 Used by the API module and the scheduler to expose real-time statistics.
 Recent commits expanded metrics to track scraper success counts and strategy
 weights for regression tests.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/observability/AGENTS.md
+++ b/observability/AGENTS.md
@@ -8,3 +8,5 @@ Utilities for logging, metrics and tracing.
 Other packages import these modules to report status and errors.
 Logging now includes the scheduler startup routine and prints first-row samples
 from scrapers during testing for easier debugging.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/risk/AGENTS.md
+++ b/risk/AGENTS.md
@@ -9,3 +9,5 @@ Risk management models and limits.
 Strategies query these modules before executing trades.
 The circuit breaker now stores breach events in DuckDB so tests can verify
 triggered stops without a running Postgres instance.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/scrapers/AGENTS.md
+++ b/scrapers/AGENTS.md
@@ -16,3 +16,5 @@ Google Trends, lobbying and Finviz. All scrapers obtain a logger via
 `get_logger(__name__)` so log output is consistent across modules.
 Network errors are handled by a simple retry helper. The `DynamicRateLimiter`
 ensures polite crawling so external services are not overwhelmed.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/scrapers/analyst_ratings.py
+++ b/scrapers/analyst_ratings.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Iterable, List
+import json
+from typing import Iterable, List, Optional
 
 import pandas as pd
 import yfinance as yf
 from bs4 import BeautifulSoup, Tag
-from typing import cast
+try:
+    from playwright.async_api import async_playwright
+except Exception:  # noqa: S110 - optional dependency
+    async_playwright = None
 
 from infra.smart_scraper import get as scrape_get
 from infra.rate_limiter import DynamicRateLimiter
@@ -21,78 +25,193 @@ analyst_coll = db["analyst_ratings"] if db else pf_coll
 rate = DynamicRateLimiter(1, QUIVER_RATE_SEC)
 log = get_logger(__name__)
 
+# URL scraped via Playwright
+BENZINGA_UPGRADES_URL = "https://www.benzinga.com/analyst-ratings/upgrades"
+
 
 async def _fetch_ticker(sym: str) -> pd.DataFrame:
+    """Return recent upgrade records for ``sym`` from Benzinga."""
     log.info(f"_fetch_ticker start sym={sym}")
-    init_db()
-    url = f"https://finviz.com/quote.ashx?t={sym}&ty=c&p=d&b=1"
-    with scrape_latency.labels("analyst_ratings").time():
-        try:
-            async with rate:
-                html = await scrape_get(url)
-        except Exception as exc:
-            scrape_errors.labels("analyst_ratings").inc()
-            log.warning(f"_fetch_ticker failed for {sym}: {exc}")
-            raise
-    soup = BeautifulSoup(html, "html.parser")
-    table = soup.find("table", class_="js-table-ratings")
-    if not isinstance(table, Tag):
-        return pd.DataFrame()
-    table = cast(Tag, table)
-    rows = []
-    now = dt.datetime.now(dt.timezone.utc)
-    for row in table.find_all("tr")[1:]:
-        if not isinstance(row, Tag):
-            continue
-        cells = [c.get_text(strip=True) for c in row.find_all("td")]
-        if len(cells) < 2:
-            continue
-        item = {
-            "ticker": sym,
-            "date": cells[0],
-            "rating": cells[1].lower(),
-            "_retrieved": now,
-        }
-        rows.append(item)
-        analyst_coll.update_one(
-            {"ticker": item["ticker"], "date": item["date"], "rating": item["rating"]},
-            {"$set": item},
-            upsert=True,
-        )
-    append_snapshot("analyst_ratings", rows)
-    df = pd.DataFrame(rows)
-    df["date"] = pd.to_datetime(df["date"], format="%Y-%m-%d", errors="coerce")
+    records = await fetch_analyst_ratings(limit=200)
+    df = pd.DataFrame(records)
+    if df.empty:
+        return df
+    df = df[df["ticker"].str.upper() == sym.upper()]  # filter for ticker
+    df["date"] = pd.to_datetime(df["date_utc"], errors="coerce")
     df = df.dropna(subset=["date"])
+    df = df.assign(rating="upgrade")[["date", "rating"]]
     log.info(f"fetched {len(df)} analyst rows for {sym}")
     return df
 
 
-async def fetch_analyst_ratings(symbols: Iterable[str]) -> List[dict]:
-    """Fetch analyst rating tables for a list of tickers."""
+TIERS = [
+    "Sell",
+    "Underperform",
+    "Underweight",
+    "Hold",
+    "Neutral",
+    "Market Perform",
+    "Perform",
+    "Equal-Weight",
+    "Sector Perform",
+    "In-Line",
+    "Peer Perform",
+    "Accumulate",
+    "Buy",
+    "Outperform",
+    "Overweight",
+    "Strong Buy",
+]
+
+
+def _tier_rank(r: str) -> int:
+    try:
+        return TIERS.index(r.title())
+    except ValueError:
+        return -1
+
+
+def _get(row: dict, keys: Iterable[str]) -> Optional[str]:
+    for k in keys:
+        if k in row and row[k] not in (None, ""):
+            return str(row[k])
+    return None
+
+
+def _find_rows(obj: object) -> Optional[List[dict]]:
+    if isinstance(obj, list):
+        if obj and isinstance(obj[0], dict) and (
+            "ticker" in obj[0] or "symbol" in obj[0]
+        ):
+            return obj  # type: ignore[return-value]
+        for item in obj:
+            out = _find_rows(item)
+            if out is not None:
+                return out
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            out = _find_rows(v)
+            if out is not None:
+                return out
+    return None
+
+
+async def fetch_analyst_ratings(limit: int = 15) -> List[dict]:
+    """Fetch latest analyst upgrades from Benzinga."""
     log.info("fetch_analyst_ratings start")
-    all_rows: List[dict] = []
-    for sym in symbols:
+    init_db()
+    url = BENZINGA_UPGRADES_URL
+    with scrape_latency.labels("analyst_ratings").time():
         try:
-            df = await _fetch_ticker(sym)
-        except Exception:
+            if async_playwright is None:
+                raise RuntimeError("playwright not installed")
+            async with rate:
+                async with async_playwright() as pw:
+                    browser = await pw.chromium.launch(headless=True)
+                    page = await browser.new_page()
+                    await page.goto(url)
+                    html = await page.content()
+                    await browser.close()
+        except Exception as exc:  # pragma: no cover - network optional
+            scrape_errors.labels("analyst_ratings").inc()
+            log.warning(f"fetch_analyst_ratings failed: {exc}")
+            raise
+    soup = BeautifulSoup(html, "html.parser")
+    script = soup.find("script", id="__NEXT_DATA__")
+    if not isinstance(script, Tag) or not script.string:
+        raise RuntimeError("__NEXT_DATA__ not found")
+    data = json.loads(script.string)
+    rows = _find_rows(data)
+    if rows is None:
+        raise RuntimeError("analyst rows not found in page data")
+
+    out: List[dict] = []
+    now = dt.datetime.now(dt.timezone.utc)
+    for row in rows:
+        if len(out) >= limit:
+            break
+        rating_cur = _get(row, ["rating_current", "rating", "new_rating"])
+        rating_prev = _get(
+            row,
+            [
+                "rating_prior",
+                "rating_previous",
+                "old_rating",
+                "previous_rating",
+            ],
+        )
+        pt_cur = _get(row, ["pt_current", "price_target", "pt_after"])
+        pt_prev = _get(row, ["pt_prior", "price_target_prior", "pt_before"])
+        pct = _get(row, ["pt_pct_change", "pt_change_pct"])
+        pct_val: Optional[float] = None
+        if pct is not None:
+            try:
+                pct_val = float(str(pct).replace("%", ""))
+            except Exception:
+                pct_val = None
+        elif pt_cur is not None and pt_prev is not None:
+            try:
+                pct_val = (
+                    (float(pt_cur) - float(pt_prev)) / float(pt_prev) * 100
+                )
+            except Exception:
+                pct_val = None
+
+        is_upgrade = False
+        if rating_cur and rating_prev:
+            is_upgrade = _tier_rank(rating_cur) > _tier_rank(rating_prev)
+
+        include = is_upgrade or (pct_val is not None and pct_val >= 5)
+        if not include:
             continue
-        all_rows.extend(df.to_dict("records"))
-    log.info(f"fetched {len(all_rows)} analyst rating rows")
-    return all_rows
+
+        if is_upgrade and pct_val is not None and pct_val >= 5:
+            action = "UPGRADE_PT_RAISE"
+        elif is_upgrade:
+            action = "UPGRADE"
+        else:
+            action = "PT_RAISE"
+
+        item = {
+            "date_utc": _get(row, ["date", "date_utc", "time"]) or now.isoformat(),
+            "ticker": _get(row, ["ticker", "symbol"]) or "",
+            "company": _get(row, ["company", "name", "company_name"]) or "",
+            "analyst": _get(row, ["analyst", "firm", "analyst_name"]) or "",
+            "rating_prior": rating_prev or "",
+            "rating_current": rating_cur or "",
+            "pt_prior": pt_prev or "",
+            "pt_current": pt_cur or "",
+            "pt_pct_change": pct_val,
+            "action": action,
+            "_retrieved": now,
+        }
+        out.append(item)
+    append_snapshot("analyst_ratings", out)
+    log.info(f"fetched {len(out)} analyst rows")
+    return out
 
 
 async def fetch_changes(symbols: Iterable[str], weeks: int = 4) -> pd.DataFrame:
-    cutoff = pd.Timestamp.today() - pd.Timedelta(weeks=weeks)
+    """Summary counts of recent upgrades per ticker."""
+    cutoff = pd.Timestamp.today(tz=dt.timezone.utc) - pd.Timedelta(weeks=weeks)
+    all_records = await fetch_analyst_ratings(limit=200)
+    df = pd.DataFrame(all_records)
+    if df.empty:
+        return pd.DataFrame(columns=[
+            "symbol",
+            "upgrades",
+            "downgrades",
+            "total",
+            "targetMeanPrice",
+            "numAnalystOpinions",
+        ])
+    df["date"] = pd.to_datetime(df["date_utc"], errors="coerce")
+    df = df.dropna(subset=["date"])
+    df = df[df["date"] >= cutoff]
     rows: List[dict] = []
     for sym in symbols:
-        try:
-            df = await _fetch_ticker(sym)
-        except Exception:
-            continue
-        df = df[df["date"] >= cutoff]
-        up = df["rating"].str.contains("upgrade").sum()
-        down = df["rating"].str.contains("downgrade").sum()
-        tot = len(df)
+        sub = df[df["ticker"].str.upper() == sym.upper()]
+        up = int(sub["action"].str.contains("UPGRADE").sum())
         info = {}
         try:
             info = yf.Ticker(sym).info
@@ -101,11 +220,19 @@ async def fetch_changes(symbols: Iterable[str], weeks: int = 4) -> pd.DataFrame:
         rows.append(
             dict(
                 symbol=sym,
-                upgrades=int(up),
-                downgrades=int(down),
-                total=int(tot),
+                upgrades=up,
+                downgrades=0,
+                total=len(sub),
                 targetMeanPrice=info.get("targetMeanPrice"),
                 numAnalystOpinions=info.get("numberOfAnalystOpinions"),
             )
         )
     return pd.DataFrame(rows)
+
+
+if __name__ == "__main__":
+    import asyncio
+    import pandas as pd
+
+    df = pd.DataFrame(asyncio.run(fetch_analyst_ratings()))
+    print(df.to_csv(sep="\t", index=False))

--- a/scrapers/analyst_ratings.py
+++ b/scrapers/analyst_ratings.py
@@ -7,8 +7,12 @@ from typing import Iterable, List, Optional
 import pandas as pd
 import yfinance as yf
 from bs4 import BeautifulSoup, Tag
+from typing import Callable, Any
+
+async_playwright: Callable[..., Any] | None
 try:
-    from playwright.async_api import async_playwright
+    from playwright.async_api import async_playwright as _ap
+    async_playwright = _ap
 except Exception:  # noqa: S110 - optional dependency
     async_playwright = None
 

--- a/scrapers/apewisdom_api.py
+++ b/scrapers/apewisdom_api.py
@@ -1,0 +1,95 @@
+"""ApeWisdom mention data helper.
+
+Fetch ticker mentions from ApeWisdom public API.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+
+import pandas as pd
+import requests
+
+from service.logger import get_logger
+
+log = get_logger(__name__)
+
+BASE = "https://apewisdom.io/api/v1.0/filter/{filter}/page/{page}"
+FILTERS = {
+    "all",
+    "all-stocks",
+    "all-crypto",
+    "4chan",
+    "CryptoCurrency",
+    "CryptoCurrencies",
+    "Bitcoin",
+    "SatoshiStreetBets",
+    "CryptoMoonShots",
+    "CryptoMarkets",
+    "stocks",
+    "wallstreetbets",
+    "options",
+    "WallStreetbetsELITE",
+    "Wallstreetbetsnew",
+    "SPACs",
+    "investing",
+    "Daytrading",
+}
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def fetch_page(filter_name: str, page: int) -> dict:
+    url = BASE.format(filter=filter_name, page=page)
+    r = requests.get(url, headers=HEADERS, timeout=20)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_mentions(filter_name: str = "wallstreetbets", limit: int = 20) -> pd.DataFrame:
+    if filter_name not in FILTERS:
+        raise ValueError(f"Unsupported filter '{filter_name}'")
+    if limit <= 0:
+        raise ValueError("limit must be > 0")
+
+    rows: List[dict] = []
+    page = 1
+    while len(rows) < limit:
+        data = fetch_page(filter_name, page)
+        for rec in data.get("results", []):
+            rows.append(rec)
+            if len(rows) >= limit:
+                break
+        if page >= data.get("pages", 0):
+            break
+        page += 1
+
+    df = pd.DataFrame(rows[:limit])
+    int_cols = ["rank", "mentions", "upvotes", "rank_24h_ago", "mentions_24h_ago"]
+    for c in int_cols:
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce").astype("Int64")
+    df["retrieved_utc"] = dt.datetime.now(dt.timezone.utc)
+    order = [
+        c
+        for c in [
+            "rank",
+            "ticker",
+            "name",
+            "mentions",
+            "upvotes",
+            "rank_24h_ago",
+            "mentions_24h_ago",
+            "retrieved_utc",
+        ]
+        if c in df.columns
+    ]
+    df = df[order]
+    return df.sort_values("rank").reset_index(drop=True)
+
+
+if __name__ == "__main__":
+    df = get_mentions("wallstreetbets", 20)
+    print(f"ROWS={len(df)} COLUMNS={df.shape[1]}")
+

--- a/scrapers/finviz_fundamentals.py
+++ b/scrapers/finviz_fundamentals.py
@@ -7,8 +7,12 @@ from typing import Dict, Optional
 
 import yfinance as yf
 from bs4 import BeautifulSoup, Tag
+from typing import Callable, Any
+
+sync_playwright: Callable[..., Any] | None
 try:
-    from playwright.sync_api import sync_playwright
+    from playwright.sync_api import sync_playwright as _sp
+    sync_playwright = _sp
 except Exception:  # noqa: S110
     sync_playwright = None
 

--- a/scrapers/finviz_fundamentals.py
+++ b/scrapers/finviz_fundamentals.py
@@ -107,3 +107,11 @@ def fetch_fundamentals(symbol: str) -> Dict[str, float | None | str]:
     }
     log.info("fetch_fundamentals complete")
     return data
+
+
+if __name__ == "__main__":
+    import pandas as pd
+    sym = "AAPL"
+    data = fetch_fundamentals(sym)
+    df = pd.DataFrame([data])
+    print(f"ROWS={len(df)} COLUMNS={df.shape[1]}")

--- a/scrapers/google_trends.py
+++ b/scrapers/google_trends.py
@@ -2,8 +2,12 @@ import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
+from typing import Callable, Any
+
+async_playwright: Callable[..., Any] | None
 try:
-    from playwright.async_api import async_playwright
+    from playwright.async_api import async_playwright as _ap
+    async_playwright = _ap
 except Exception:  # noqa: S110
     async_playwright = None
 

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -2,8 +2,12 @@ import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
 from bs4.element import Tag
+from typing import Callable, Any
+
+async_playwright: Callable[..., Any] | None
 try:
-    from playwright.async_api import async_playwright
+    from playwright.async_api import async_playwright as _ap
+    async_playwright = _ap
 except Exception:  # noqa: S110
     async_playwright = None
 from service.config import QUIVER_RATE_SEC

--- a/scrapers/universe.py
+++ b/scrapers/universe.py
@@ -8,8 +8,12 @@ from typing import List
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
+from typing import Callable, Any
+
+sync_playwright: Callable[..., Any] | None
 try:
-    from playwright.sync_api import sync_playwright
+    from playwright.sync_api import sync_playwright as _sp
+    sync_playwright = _sp
 except Exception:  # noqa: S110 - optional dependency
     sync_playwright = None
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,3 +6,5 @@ Assorted command-line tools.
   system checklist and then runs all scrapers once.
 - `bootstrap.sh` assumes the repo is already downloaded, installs requirements, runs all scrapers once and registers a systemd service. The Postgres user and database must already exist.
 - `health_check.py` reports system status including portfolio and metric counts.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -33,63 +33,99 @@ _log = get_logger("bootstrap")
 async def system_checklist() -> None:
     """Verify connectivity to core components."""
     errs = []
-    if not db_ping():
+
+    if db_ping():
+        _log.info("postgres PASS")
+    else:
+        _log.warning("postgres FAIL")
         errs.append("postgres")
+
     try:
         gw = AlpacaGateway()
         await gw.account()
         await gw.close()
+        _log.info("alpaca PASS")
     except Exception as exc:  # pragma: no cover - network optional
+        _log.warning(f"alpaca FAIL: {exc}")
         errs.append(f"alpaca: {exc}")
+
     try:
         led = MasterLedger()
         await led.redis.ping()
+        _log.info("ledger PASS")
     except Exception as exc:  # pragma: no cover - redis optional
+        _log.warning(f"ledger FAIL: {exc}")
         errs.append(f"ledger: {exc}")
+
     try:
-        df = pd.DataFrame(
-            {"A": [0.1, -0.1], "B": [0.05, 0.02]},
-            index=pd.to_datetime(["2024-01-01", "2024-01-08"]),
-        )
+        df = pd.DataFrame({"A": [0.1, -0.1], "B": [0.05, 0.02]}, index=pd.to_datetime(["2024-01-01", "2024-01-08"]))
         compute_weights(df)
+        _log.info("allocation PASS")
     except Exception as exc:  # pragma: no cover - numeric errors
+        _log.warning(f"allocation FAIL: {exc}")
         errs.append(f"allocation: {exc}")
+
     if errs:
         _log.warning({"checklist": errs})
         raise RuntimeError("; ".join(errs))
-    _log.info("system checklist passed")
+    _log.info("system checklist complete")
 
 
 async def run_scrapers() -> None:
-    # scrape universe first to ensure downstream scrapers have a full ticker list
+    """Run all scrapers sequentially and log row counts."""
     await asyncio.to_thread(download_sp500)
     await asyncio.to_thread(download_sp400)
     await asyncio.to_thread(download_russell2000)
     universe = set(load_sp500()) | set(load_sp400()) | set(load_russell2000())
     if len(universe) < 2000:
         _log.warning(f"universe size {len(universe)} < 2000")
-    await asyncio.gather(
-        fetch_politician_trades(),
-        fetch_lobbying_data(),
-        fetch_trending_wiki_views(),
-        fetch_dc_insider_scores(),
-        fetch_gov_contracts(),
-        fetch_app_reviews(),
-        fetch_google_trends(),
-        fetch_wsb_mentions(),
-        fetch_analyst_ratings(["AAPL", "MSFT"]),
-        fetch_insider_buying(),
-        fetch_stock_news(),
-        asyncio.to_thread(fetch_sp500_history, 365),
-        asyncio.to_thread(update_all_ticker_scores),
-    )
+
+    scrapers = [
+        ("politician_trades", fetch_politician_trades),
+        ("lobbying", fetch_lobbying_data),
+        ("wiki_views", fetch_trending_wiki_views),
+        ("dc_insider_scores", fetch_dc_insider_scores),
+        ("gov_contracts", fetch_gov_contracts),
+        ("app_reviews", fetch_app_reviews),
+        ("google_trends", fetch_google_trends),
+        ("wsb_mentions", fetch_wsb_mentions),
+        ("analyst_ratings", fetch_analyst_ratings),
+        ("insider_buying", fetch_insider_buying),
+        ("stock_news", fetch_stock_news),
+        ("sp500_history", lambda: fetch_sp500_history(365)),
+        ("ticker_scores", update_all_ticker_scores),
+    ]
+
+    for name, func in scrapers:
+        try:
+            result = func()
+            if asyncio.iscoroutine(result):
+                data = await result
+            else:
+                data = result
+            rows = cols = 0
+            if isinstance(data, pd.DataFrame):
+                rows, cols = data.shape
+            elif isinstance(data, (list, tuple)):
+                rows = len(data)
+                if rows and isinstance(data[0], dict):
+                    cols = len(data[0])
+            elif isinstance(data, dict):
+                rows = len(data)
+                if rows:
+                    val = next(iter(data.values()))
+                    if isinstance(val, dict):
+                        cols = len(val)
+            _log.info(f"{name} PASS {rows}x{cols}")
+        except Exception as exc:
+            _log.warning(f"{name} FAIL: {exc}")
 
 
 def main() -> None:
     _log.info("initialising database and running scrapers")
     init_db()
-    asyncio.run(system_checklist())
     asyncio.run(run_scrapers())
+    asyncio.run(system_checklist())
     _log.info("bootstrap complete")
 
 

--- a/service/AGENTS.md
+++ b/service/AGENTS.md
@@ -1,0 +1,10 @@
+# Folder Overview
+
+Service layer exposing the REST API and scheduler.
+- `api.py` defines FastAPI endpoints and portfolio operations.
+- `start.py` validates startup and runs all scrapers once.
+- `scheduler.py` schedules recurring jobs using APScheduler.
+- `logger.py` wraps the structlog helpers for consistent logging.
+- `config.py` and `config.yaml` hold environment configuration.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/service/api.py
+++ b/service/api.py
@@ -155,7 +155,7 @@ async def startup_event():
             fetch_app_reviews(),
             fetch_google_trends(),
             fetch_wsb_mentions(),
-            fetch_analyst_ratings(["AAPL", "MSFT"]),
+            fetch_analyst_ratings(),
             fetch_insider_buying(),
             fetch_stock_news(),
             asyncio.to_thread(fetch_sp500_history, 365),

--- a/service/start.py
+++ b/service/start.py
@@ -38,7 +38,7 @@ SCRAPERS = [
     ("app_reviews", fetch_app_reviews),
     ("google_trends", fetch_google_trends),
     ("wsb_mentions", fetch_wsb_mentions),
-    ("analyst_ratings", lambda: fetch_analyst_ratings(["AAPL", "MSFT"])),
+    ("analyst_ratings", fetch_analyst_ratings),
     ("insider_buying", fetch_insider_buying),
     ("stock_news", fetch_stock_news),
     ("sp500_history", lambda: fetch_sp500_history(365)),

--- a/strategies/AGENTS.md
+++ b/strategies/AGENTS.md
@@ -8,3 +8,5 @@ Strategies now cover the Congressional-Trading Aggregate, DC insider scores,
 government contracts, app reviews, Google Trends and politician sleeves for
 Nancy Pelosi, Dan Meuser and Shelley Moore Capito. They are executed on a
 schedule and validated by unit tests.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,3 +5,5 @@ test fetches one record from mocked data sources so the pipelines run without
 network access. Strategy tests exercise the Congressional-Trading Aggregate
 along with the Pelosi, Meuser and Capito sleeves and all other models. The
 `pytest -q` command is run before every commit.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -75,3 +75,21 @@ async def test_system_checklist(monkeypatch):
     monkeypatch.setattr(boot, "AlpacaGateway", lambda: DummyGW())
     monkeypatch.setattr(boot, "MasterLedger", DummyLedger)
     await boot.system_checklist()
+
+
+def test_bootstrap_main_order(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(boot, "init_db", lambda: calls.append("init"))
+
+    async def fake_scrapers():
+        calls.append("scrapers")
+
+    async def fake_checklist():
+        calls.append("checklist")
+
+    monkeypatch.setattr(boot, "run_scrapers", fake_scrapers)
+    monkeypatch.setattr(boot, "system_checklist", fake_checklist)
+
+    boot.main()
+    assert calls == ["init", "scrapers", "checklist"]

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -109,12 +109,12 @@ async def test_scraper_suite(
 
 
 def test_helpers(monkeypatch, tmp_path):
-    df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01"]), "rating": ["upgrade"]})
+    data = [{"date_utc": "2024-01-01T00:00:00Z", "ticker": "AAPL", "action": "UPGRADE"}]
 
-    async def fake_fetch(sym):
-        return df
+    async def fake_fetch(limit=200):
+        return data
 
-    monkeypatch.setattr(ar, "_fetch_ticker", fake_fetch)
+    monkeypatch.setattr(ar, "fetch_analyst_ratings", fake_fetch)
     out = asyncio.run(ar.fetch_changes(["AAPL"], weeks=4))
     assert not out.empty and out.iloc[0]["symbol"] == "AAPL"
     print(out.iloc[0])

--- a/ws/AGENTS.md
+++ b/ws/AGENTS.md
@@ -6,3 +6,5 @@ WebSocket hub used for push updates to the frontend.
 Depends on the API module to orchestrate portfolio events.
 Recent commits added automatic connection metrics so clients can monitor feed
 health via Prometheus.
+
+- **Reminder:** triple-check modifications and run tests to prevent regressions.


### PR DESCRIPTION
## Summary
- swap per-ticker analyst scraping to Benzinga data
- adjust upgrade momentum helper and tests for the new interface
- append triple-check reminder to every `AGENTS.md`
- add explicit Benzinga URL constant and improved bootstrap health checks

## Testing
- `pip install -q -r deploy/requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a7d5476888323afa160385287a299