### PR TITLE
Fix dashboard import path

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
+"""CLI dashboard for inspecting API health and table samples."""
+
 import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
 import requests
 import pandas as pd
 from service.config import API_TOKEN


### PR DESCRIPTION
## Summary
- ensure dashboard can import config

## Testing
- `pytest -q`
- `python scripts/dashboard.py | head -n 5` *(fails to connect but imports config)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a0fd3fc8323b405203ffe09ab81