### PR TITLE
Fix MariaDB cache schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ performance monitoring.
 - `account_metrics_live` – equity history for the live account
 - `account_metrics` – point-in-time equity snapshots
 - `schema_version` – schema migration tracking
-- `cache` – key/value store for HTTP responses
+ - `cache` – key/value store for HTTP responses (`cache_key`, `payload`, `expire`)
 - `alloc_log` – allocation diagnostics
 - `system_logs` – structured log records for the front end
 - `top_scores` – top 20 tickers by composite score each month

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -60,15 +60,15 @@ class InMemoryCollection:
         self._store: dict[str, dict[str, Any]] = {}
 
     def find_one(self, q: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        key = q.get("key")
-        if not isinstance(key, str):
+        cache_key = q.get("cache_key")
+        if not isinstance(cache_key, str):
             return None
-        return self._store.get(key)
+        return self._store.get(cache_key)
 
     def replace_one(
         self, match: Dict[str, Any], doc: Dict[str, Any], upsert: bool = False
     ) -> None:
-        self._store[match["key"]] = doc
+        self._store[match["cache_key"]] = doc
 
 
 class PGClient:

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -210,7 +210,7 @@ CREATE TABLE IF NOT EXISTS alloc_log (
 );
 
 CREATE TABLE IF NOT EXISTS cache (
-    key VARCHAR(191) PRIMARY KEY,
+    cache_key VARCHAR(191) PRIMARY KEY,
     payload TEXT,
     expire TIMESTAMP
 );

--- a/infra/smart_scraper.py
+++ b/infra/smart_scraper.py
@@ -32,7 +32,7 @@ async def get(url: str, retries: int = 3) -> str:
     """
 
     key = hashlib.md5(url.encode()).hexdigest()
-    doc = cache.find_one({"key": key})
+    doc = cache.find_one({"cache_key": key})
     if doc:
         expire = doc.get("expire")
         if expire is not None:
@@ -59,9 +59,9 @@ async def get(url: str, retries: int = 3) -> str:
 
                 text = await asyncio.to_thread(_fetch)
                 cache.replace_one(
-                    {"key": key},
+                    {"cache_key": key},
                     {
-                        "key": key,
+                        "cache_key": key,
                         "payload": text,
                         "expire": dt.datetime.now(dt.timezone.utc)
                         + dt.timedelta(seconds=TTL),

--- a/tests/test_smart_scraper.py
+++ b/tests/test_smart_scraper.py
@@ -8,12 +8,24 @@ from database import InMemoryCollection
 
 @pytest.mark.asyncio
 async def test_get_handles_naive_expire(monkeypatch):
-    url = 'http://example.com'
+    url = "http://example.com"
     key = hashlib.md5(url.encode()).hexdigest()
     mem = InMemoryCollection()
-    mem.replace_one({'key': key}, {'key': key, 'payload': 'cached', 'expire': dt.datetime.now() + dt.timedelta(seconds=60)}, upsert=True)
-    monkeypatch.setattr(smart_scraper, 'cache', mem)
-    monkeypatch.setattr(smart_scraper.requests, 'get', lambda *a, **k: (_ for _ in ()).throw(AssertionError('network')))
+    mem.replace_one(
+        {"cache_key": key},
+        {
+            "cache_key": key,
+            "payload": "cached",
+            "expire": dt.datetime.now() + dt.timedelta(seconds=60),
+        },
+        upsert=True,
+    )
+    monkeypatch.setattr(smart_scraper, "cache", mem)
+    monkeypatch.setattr(
+        smart_scraper.requests,
+        "get",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("network")),
+    )
 
     result = await smart_scraper.get(url)
-    assert result == 'cached'
+    assert result == "cached"


### PR DESCRIPTION
## Summary
- give the cache table a column name (`cache_key`)
- update in-memory DB helper to use new field
- adjust smart scraper and tests for column rename
- document cache table fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c7e067c08323901f47d35a36be3a