### PR TITLE
Improve startup and README docs

### DIFF
--- a/scripts/populate.py
+++ b/scripts/populate.py
@@ -62,6 +62,7 @@ async def run_scrapers() -> None:
     today = pd.Timestamp.utcnow().normalize()
 
     for name, func in scrapers:
+        _log.info(f"{name} start")
         try:
             table = table_map.get(name, name)
             if has_recent_rows(table, today):

--- a/service/config.py
+++ b/service/config.py
@@ -51,9 +51,12 @@ class Settings(BaseSettings):
     these settings can be loaded without a separate ``.env`` file.
     """
 
-    ALPACA_API_KEY: str | None = None
-    ALPACA_API_SECRET: str | None = None
-    ALPACA_BASE_URL: str = "https://paper-api.alpaca.markets"
+    ALPACA_PAPER_KEY: str | None = None
+    ALPACA_PAPER_SECRET: str | None = None
+    ALPACA_PAPER_URL: str = "https://paper-api.alpaca.markets"
+    ALPACA_LIVE_KEY: str | None = None
+    ALPACA_LIVE_SECRET: str | None = None
+    ALPACA_LIVE_URL: str = "https://api.alpaca.markets"
     ALLOW_LIVE: bool = False
 
     QUIVER_RATE_SEC: float = 1.1
@@ -80,9 +83,13 @@ class Settings(BaseSettings):
 # Pass defaults explicitly so mypy recognises optional fields
 settings = Settings(MIN_ALLOCATION=0.02, MAX_ALLOCATION=0.40, CACHE_TTL=900)
 
-ALPACA_API_KEY = settings.ALPACA_API_KEY
-ALPACA_API_SECRET = settings.ALPACA_API_SECRET
-ALPACA_BASE_URL = settings.ALPACA_BASE_URL
+ALLOW_LIVE = settings.ALLOW_LIVE
+
+ALPACA_API_KEY = settings.ALPACA_LIVE_KEY if ALLOW_LIVE else settings.ALPACA_PAPER_KEY
+ALPACA_API_SECRET = (
+    settings.ALPACA_LIVE_SECRET if ALLOW_LIVE else settings.ALPACA_PAPER_SECRET
+)
+ALPACA_BASE_URL = settings.ALPACA_LIVE_URL if ALLOW_LIVE else settings.ALPACA_PAPER_URL
 
 QUIVER_RATE_SEC = settings.QUIVER_RATE_SEC
 
@@ -106,4 +113,3 @@ CRON = {
 }
 
 AUTO_START_SCHED = settings.AUTO_START_SCHED
-ALLOW_LIVE = settings.ALLOW_LIVE

--- a/service/config.yaml
+++ b/service/config.yaml
@@ -1,6 +1,10 @@
-ALPACA_API_KEY: "your-alpaca-key"
-ALPACA_API_SECRET: "your-secret"
-ALPACA_BASE_URL: "https://paper-api.alpaca.markets"
+ALPACA_PAPER_KEY: "your-paper-key"
+ALPACA_PAPER_SECRET: "your-paper-secret"
+ALPACA_PAPER_URL: "https://paper-api.alpaca.markets"
+ALPACA_LIVE_KEY: "your-live-key"
+ALPACA_LIVE_SECRET: "your-live-secret"
+ALPACA_LIVE_URL: "https://api.alpaca.markets"
+ALLOW_LIVE: false
 PG_URI: "mysql+pymysql://maria:maria@localhost:3306/quant_fund"
 FRED_API_KEY: "your-fred-key"
 API_TOKEN: "changeme"

--- a/strategies/google_trends.py
+++ b/strategies/google_trends.py
@@ -24,7 +24,11 @@ _pipe: Optional["TextClassificationPipeline"]
 
 if pipeline is not None:
     try:  # pragma: no cover - download may fail
-        _pipe = pipeline(task="text-classification")
+        _pipe = pipeline(
+            task="text-classification",
+            model="distilbert/distilbert-base-uncased-finetuned-sst-2-english",
+            revision="714eb0f",
+        )
     except Exception:  # pragma: no cover - fallback
         _pipe = None
 else:  # pragma: no cover - pipeline import failure


### PR DESCRIPTION
## Summary
- ensure API dashboard starts immediately and scrape jobs run in background
- log each scraper before execution
- explain paper vs live Alpaca setup and dashboard access in README
- add separate live Alpaca credentials in config

## Testing
- `pip install -r deploy/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881fc843e68832399b3727b7ecdeff5