### PR TITLE
Add redis bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@ The Portfolio Allocation System is an end-to-end trading platform that runs enti
 
    The service appends `/v2/account` to the Alpaca URLs automatically, so do **not** include the `/v2` prefix in the configuration.
 
-3. **Enable remote MariaDB access**
+3. **Setup Redis**
+
+   ```bash
+   sudo scripts/setup_redis.sh
+   ```
+   (This step is also run automatically by `bootstrap.sh`.)
+
+4. **Enable remote MariaDB access**
 
    Set `bind-address = 0.0.0.0` in `/etc/mysql/mariadb.conf.d/50-server.cnf` and open port `3306` on the firewall so the API and scrapers can connect.
 
-4. **Start all services**
+5. **Start all services**
 
    ```bash
    sudo scripts/bootstrap.sh
@@ -40,7 +47,7 @@ The Portfolio Allocation System is an end-to-end trading platform that runs enti
 
    This registers a systemd unit that runs `service/start.py` and launches the API at `http://192.168.0.59:8001`.
 
-5. **Run the unit tests** *(optional)*
+6. **Run the unit tests** *(optional)*
 
    ```bash
    pip install -r deploy/requirements-test.txt

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -4,7 +4,8 @@ Assorted command-line tools.
 - `wsb_cli.py` runs a WallStreetBets sentiment analysis for experimentation. The optional transformers dependency is handled gracefully so tests run without GPU support.
 - `bootstrap.py` now delegates to `service.start.main`; it simply runs the
   system checklist and then launches the full startup sequence.
- - `bootstrap.sh` assumes the repo is already downloaded, installs requirements, runs all scrapers once and registers a systemd service. The MariaDB user and database are created automatically.
+- `bootstrap.sh` assumes the repo is already downloaded, installs requirements, runs all scrapers once and registers a systemd service. The MariaDB user and database are created automatically.
+- `setup_redis.sh` installs Redis, configures the bind address and enables the systemd service.
 - `health_check.py` reports system status including portfolio and metric counts.
 
 - **Reminder:** triple-check modifications and run tests to prevent regressions.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,6 +15,7 @@ pip install --upgrade pip
 pip install -r "$APP_DIR/deploy/requirements.txt"
 sudo apt-get update
 sudo apt-get install -y mariadb-server
+"$APP_DIR/scripts/setup_redis.sh"
 sudo systemctl enable mariadb
 sudo systemctl start mariadb
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS quant_fund;"
@@ -26,8 +27,8 @@ python -m playwright install chromium || true
 cat <<EOF >/etc/systemd/system/portfolio.service
 [Unit]
 Description=Portfolio Service
-After=network.target mariadb.service
-Requires=mariadb.service
+After=network.target mariadb.service redis-server.service
+Requires=mariadb.service redis-server.service
 
 [Service]
 Type=simple

--- a/scripts/setup_redis.sh
+++ b/scripts/setup_redis.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install and configure Redis for the portfolio system.
+set -euo pipefail
+
+REDIS_IP="192.168.0.59"
+
+sudo apt-get update
+sudo apt-get install -y redis-server
+
+# Bind Redis to the expected interface
+sudo sed -i "s/^bind .*/bind ${REDIS_IP}/" /etc/redis/redis.conf
+
+sudo systemctl enable --now redis-server.service
+
+echo "Redis running on ${REDIS_IP}:6379"


### PR DESCRIPTION
## Summary
- document new `setup_redis.sh` installation step
- call redis setup from `bootstrap.sh`
- enable redis service in unit file
- list `setup_redis.sh` in agent overview

## Testing
- `pip install -r deploy/requirements-test.txt`
- `pytest -q`
- `systemctl status redis-server.service` *(fails: systemd not present)*
- `systemctl status redis.service` *(fails: systemd not present)*

------
https://chatgpt.com/codex/tasks/task_e_688381b1e2cc8323ad750b9e627ac3be