### PR TITLE
docs: allow remote maria user

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Portfolio Allocation System is an end-to-end trading platform that runs enti
 4. **Enable remote MariaDB access**
 
    The `scripts/bootstrap.sh` script configures MariaDB to listen on all
-   interfaces by setting `bind-address = 0.0.0.0` in
+   interfaces by setting `bind-address = 192.168.0.59` in
    `/etc/mysql/mariadb.conf.d/50-server.cnf` and opens port `3306` on the
    firewall.  Grant the database user remote privileges so the API and scrapers
    can connect:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ The Portfolio Allocation System is an end-to-end trading platform that runs enti
 
 4. **Enable remote MariaDB access**
 
-   Set `bind-address = 0.0.0.0` in `/etc/mysql/mariadb.conf.d/50-server.cnf` and open port `3306` on the firewall so the API and scrapers can connect.
+   Set `bind-address = 0.0.0.0` in `/etc/mysql/mariadb.conf.d/50-server.cnf` and open port `3306` on the firewall.
+   Grant the database user remote privileges so the API and scrapers can connect:
+
+   ```bash
+   sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'%' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
+   ```
 
 5. **Start all services**
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,19 @@ The Portfolio Allocation System is an end-to-end trading platform that runs enti
 
 4. **Enable remote MariaDB access**
 
-   Set `bind-address = 0.0.0.0` in `/etc/mysql/mariadb.conf.d/50-server.cnf` and open port `3306` on the firewall.
-   Grant the database user remote privileges so the API and scrapers can connect:
+   The `scripts/bootstrap.sh` script configures MariaDB to listen on all
+   interfaces by setting `bind-address = 0.0.0.0` in
+   `/etc/mysql/mariadb.conf.d/50-server.cnf` and opens port `3306` on the
+   firewall.  Grant the database user remote privileges so the API and scrapers
+   can connect:
 
    ```bash
    sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'%' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
+   mysql -e 'SELECT User, Host FROM mysql.user;'
    ```
+
+   Ensure that the output lists `maria` with host `%` to confirm remote access
+   is enabled.
 
 5. **Start all services**
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,6 +15,8 @@ pip install --upgrade pip
 pip install -r "$APP_DIR/deploy/requirements.txt"
 sudo apt-get update
 sudo apt-get install -y mariadb-server
+# Bind MariaDB to all interfaces so remote clients can connect
+sudo sed -i 's/^bind-address.*/bind-address = 0.0.0.0/' /etc/mysql/mariadb.conf.d/50-server.cnf
 "$APP_DIR/scripts/setup_redis.sh"
 sudo systemctl enable mariadb
 sudo systemctl start mariadb

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y mariadb-server
 sudo systemctl enable mariadb
 sudo systemctl start mariadb
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS quant_fund;"
-sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'localhost' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
+sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'%' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
 python -m playwright install chromium || true
 
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,8 +15,8 @@ pip install --upgrade pip
 pip install -r "$APP_DIR/deploy/requirements.txt"
 sudo apt-get update
 sudo apt-get install -y mariadb-server
-# Bind MariaDB to all interfaces so remote clients can connect
-sudo sed -i 's/^bind-address.*/bind-address = 0.0.0.0/' /etc/mysql/mariadb.conf.d/50-server.cnf
+# Bind MariaDB to 192.168.0.59 so remote clients can connect
+sudo sed -i 's/^bind-address.*/bind-address = 192.168.0.59/' /etc/mysql/mariadb.conf.d/50-server.cnf
 "$APP_DIR/scripts/setup_redis.sh"
 sudo systemctl enable mariadb
 sudo systemctl start mariadb


### PR DESCRIPTION
## Summary
- allow remote DB user for bootstrap
- document remote MariaDB permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883add23eb08323939b466c7cbd0bcc