### PR TITLE
Fix import errors and show dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ After the API is running you can explore data in your browser:
 http://192.168.0.59:8001/dashboard?token=<YOUR_TOKEN>
 ```
 
-This page lists scheduled jobs and links to every database table. The same
-information is available from the command line:
+This page lists scheduled jobs and links to every database table. The dashboard
+opens automatically when `service.start` launches. The same information is
+available from the command line:
 
 ```bash
 source venv/bin/activate

--- a/scrapers/analyst_ratings.py
+++ b/scrapers/analyst_ratings.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import asyncio
 import datetime as dt
 import json
@@ -232,7 +239,7 @@ async def fetch_analyst_ratings(limit: int = 15) -> List[dict]:
             raw_df, _ = await asyncio.to_thread(fetch_upgrades, limit)
         except Exception as exc:
             scrape_errors.labels("analyst_ratings").inc()
-            log.warning(f"fetch_analyst_ratings failed: {exc}")
+            log.exception(f"fetch_analyst_ratings failed: {exc}")
             raise
 
     if raw_df.empty:

--- a/scrapers/app_reviews.py
+++ b/scrapers/app_reviews.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
@@ -27,7 +34,7 @@ async def fetch_app_reviews() -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("app_reviews").inc()
-            log.warning(f"fetch_app_reviews failed: {exc}")
+            log.exception(f"fetch_app_reviews failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))

--- a/scrapers/dc_insider.py
+++ b/scrapers/dc_insider.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
@@ -27,7 +34,7 @@ async def fetch_dc_insider_scores() -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("dc_insider_scores").inc()
-            log.warning(f"fetch_dc_insider_scores failed: {exc}")
+            log.exception(f"fetch_dc_insider_scores failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))

--- a/scrapers/full_fundamentals.py
+++ b/scrapers/full_fundamentals.py
@@ -6,6 +6,13 @@ compute quality, value, growth, momentum and risk metrics for a
 collection of tickers. Results are saved to three CSV files in the
 current directory.
 """
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import math
 import datetime as dt
 import warnings
@@ -13,10 +20,13 @@ from typing import List, Sequence, Dict, Iterable, Tuple
 
 from scrapers.universe import load_sp500, load_sp400, load_russell2000
 from database import init_db, top_score_coll
+from service.logger import get_scraper_logger
 
 import numpy as np
 import pandas as pd
 import yfinance as yf
+
+log = get_scraper_logger(__name__)
 
 PRICE_LOOKBACK_DAYS = 400
 POSITION_DOLLARS = 5_000_000
@@ -365,7 +375,8 @@ def collect_fundamentals(ticker: str):
         bs = last_two(tk.balance_sheet)
         cf = last_two(tk.cashflow)
         info = tk.info
-    except Exception:
+    except Exception as exc:
+        log.exception(f"collect_fundamentals failed for {ticker}: {exc}")
         return {}
     shares_prev = previous_shares_outstanding(ticker)
     row = {}

--- a/scrapers/google_trends.py
+++ b/scrapers/google_trends.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import Callable, Any, List, Optional, cast
 
@@ -66,7 +73,7 @@ async def fetch_google_trends() -> List[dict]:
                 html = await scrape_get(url)
             rows = parse_google_trends(html)
         except Exception as exc:  # pragma: no cover - network optional
-            log.warning(f"google_trends http failed: {exc}")
+            log.exception(f"google_trends http failed: {exc}")
             scrape_errors.labels("google_trends").inc()
         # Playwright fallback
         if not rows and HAVE_PW:
@@ -80,7 +87,7 @@ async def fetch_google_trends() -> List[dict]:
                     await browser.close()
                 rows = parse_google_trends(html)
             except Exception as exc:  # pragma: no cover - network optional
-                log.warning(f"google_trends playwright failed: {exc}")
+                log.exception(f"google_trends playwright failed: {exc}")
 
     now = dt.datetime.now(dt.timezone.utc)
     for item in rows:

--- a/scrapers/gov_contracts.py
+++ b/scrapers/gov_contracts.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
@@ -26,7 +33,7 @@ async def fetch_gov_contracts() -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("gov_contracts").inc()
-            log.warning(f"fetch_gov_contracts failed: {exc}")
+            log.exception(f"fetch_gov_contracts failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))

--- a/scrapers/insider_buying.py
+++ b/scrapers/insider_buying.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
@@ -28,7 +35,7 @@ async def fetch_insider_buying() -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("insider_buying").inc()
-            log.warning(f"fetch_insider_buying failed: {exc}")
+            log.exception(f"fetch_insider_buying failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))

--- a/scrapers/lobbying.py
+++ b/scrapers/lobbying.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import Callable, Any, List, Optional, cast
 
@@ -76,7 +83,7 @@ async def fetch_lobbying_data() -> List[dict]:
                 html = await scrape_get(url)
             rows = parse_lobbying(html)
         except Exception as exc:  # pragma: no cover - network optional
-            log.warning(f"lobbying http failed: {exc}")
+            log.exception(f"lobbying http failed: {exc}")
             scrape_errors.labels("lobbying").inc()
         # Playwright fallback
         if not rows and HAVE_PW:
@@ -90,7 +97,7 @@ async def fetch_lobbying_data() -> List[dict]:
                     await browser.close()
                 rows = parse_lobbying(html)
             except Exception as exc:  # pragma: no cover - network optional
-                log.warning(f"lobbying playwright failed: {exc}")
+                log.exception(f"lobbying playwright failed: {exc}")
 
     now = dt.datetime.now(dt.timezone.utc)
     for item in rows:

--- a/scrapers/news.py
+++ b/scrapers/news.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, cast
 from bs4 import BeautifulSoup, Tag
@@ -28,7 +35,7 @@ async def fetch_stock_news(limit: int = 50) -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("news_headlines").inc()
-            log.warning(f"fetch_stock_news failed: {exc}")
+            log.exception(f"fetch_stock_news failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     rows: List[dict] = []

--- a/scrapers/politician.py
+++ b/scrapers/politician.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List, Optional, cast
 from bs4 import BeautifulSoup
@@ -25,7 +32,7 @@ async def fetch_politician_trades() -> List[dict]:
                 html = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("politician_trades").inc()
-            log.warning(f"fetch_politician_trades failed: {exc}")
+            log.exception(f"fetch_politician_trades failed: {exc}")
             raise
     soup = BeautifulSoup(html, "html.parser")
     table = cast(Optional[Tag], soup.find("table"))

--- a/scrapers/sp500_index.py
+++ b/scrapers/sp500_index.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 from typing import List
 
@@ -32,7 +39,7 @@ def fetch_sp500_history(days: int = 365) -> List[dict]:
             )
         except Exception as exc:
             scrape_errors.labels("sp500_index").inc()
-            log.warning(f"fetch_sp500_history failed: {exc}")
+            log.exception(f"fetch_sp500_history failed: {exc}")
             raise
     if df.empty:
         return []

--- a/scrapers/universe.py
+++ b/scrapers/universe.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import io
 import datetime as dt
 from pathlib import Path
@@ -180,11 +187,11 @@ def download_russell2000(path: Path | None = None) -> Path:
         try:
             tickers = _tickers_from_financhle()
         except Exception as exc:
-            log.warning(f"financhle scrape failed: {exc}")
+            log.exception(f"financhle scrape failed: {exc}")
             try:
                 tickers = _tickers_from_marketscreener()
             except Exception as exc2:
-                log.warning(f"marketscreener scrape failed: {exc2}")
+                log.exception(f"marketscreener scrape failed: {exc2}")
                 tickers = []
     tickers = _clean_symbols(list(tickers))
     pd.DataFrame(sorted(tickers), columns=["symbol"]).to_csv(path, index=False)

--- a/scrapers/wallstreetbets.py
+++ b/scrapers/wallstreetbets.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import asyncio
 import datetime as dt
 from typing import List
@@ -47,7 +54,7 @@ def fetch_page(filter_name: str, page: int) -> dict:
         r = requests.get(url, headers=HEADERS, timeout=20)
         r.raise_for_status()
     except Exception as exc:  # pragma: no cover - network optional
-        log.warning(f"fetch_page failed: {exc}")
+        log.exception(f"fetch_page failed: {exc}")
         raise
     return r.json()
 
@@ -136,7 +143,7 @@ async def fetch_wsb_mentions(days: int = 7, top_n: int = 20) -> List[dict]:
             df = await asyncio.to_thread(get_mentions, "wallstreetbets", top_n)
         except Exception as exc:
             scrape_errors.labels("reddit_mentions").inc()
-            log.warning(f"fetch_wsb_mentions failed: {exc}")
+            log.exception(f"fetch_wsb_mentions failed: {exc}")
             raise
     if df.empty:
         return []

--- a/scrapers/wiki.py
+++ b/scrapers/wiki.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import datetime as dt
 import json
 from typing import List
@@ -36,7 +43,7 @@ async def fetch_wiki_views(page: str = "Apple_Inc", days: int = 7) -> List[dict]
                 text = await scrape_get(url)
         except Exception as exc:
             scrape_errors.labels("wiki_views").inc()
-            log.warning(f"fetch_wiki_views failed: {exc}")
+            log.exception(f"fetch_wiki_views failed: {exc}")
             raise
     items = json.loads(text).get("items", [])
     now = dt.datetime.now(dt.timezone.utc)
@@ -92,7 +99,7 @@ async def fetch_trending_wiki_views(top_k: int = 10, days: int = 7) -> List[dict
         try:
             out.extend(await fetch_wiki_views(pg, days))
         except Exception as exc:  # pragma: no cover - network optional
-            log.warning(f"fetch_wiki_views failed for {pg}: {exc}")
+            log.exception(f"fetch_wiki_views failed for {pg}: {exc}")
             continue
     log.info(f"fetched {len(out)} trending wiki rows")
     return out

--- a/service/start.py
+++ b/service/start.py
@@ -117,6 +117,17 @@ async def main(host: str | None = None, port: int | None = None) -> None:
 
     h = host or API_HOST or "192.168.0.59"
     p = port or API_PORT or 8001
+
+    url = f"http://{h}:{p}/dashboard"
+    if API_TOKEN:
+        url += f"?token={API_TOKEN}"
+    try:
+        import webbrowser
+
+        webbrowser.open(url)
+    except Exception as exc:  # pragma: no cover - env dependent
+        log.warning(f"failed to open dashboard: {exc}")
+
     await _launch_server(h, p)
 
 


### PR DESCRIPTION
## Summary
- ensure scrapers work when run directly by adjusting `sys.path`
- log full stack traces for all scraper failures
- automatically open the dashboard URL when starting the API
- note the auto-open behaviour in the README

## Testing
- `pip install -q -r deploy/requirements-test.txt` *(fails: empty log)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850bea5e18832397647f7d79976587