### PR TITLE
Start API server before startup tasks

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -8,14 +8,13 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from service.logger import get_logger
-from service.start import main as start_main, system_checklist
+from service.start import main as start_main
 
 _log = get_logger("bootstrap")
 
 
 def main() -> None:
-    asyncio.run(system_checklist())
-    _log.info("bootstrap complete")
+    _log.info("bootstrap begin")
     asyncio.run(start_main())
 
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,7 +14,13 @@ source "$VENV_DIR/bin/activate"
 pip install --upgrade pip
 pip install -r "$APP_DIR/deploy/requirements.txt"
 sudo apt-get update
-sudo apt-get install -y mariadb-server
+echo "Installing git, git-lfs and MariaDB"
+sudo apt-get install -y git git-lfs mariadb-server
+git lfs install --system
+if ! git -C "$APP_DIR" remote | grep -q backup; then
+  git -C "$APP_DIR" remote add backup https://github.com/KilianC3/Backup
+fi
+git -C "$APP_DIR" lfs install --local
 # Bind MariaDB to 192.168.0.59 so remote clients can connect
 sudo sed -i 's/^bind-address.*/bind-address = 192.168.0.59/' /etc/mysql/mariadb.conf.d/50-server.cnf
 "$APP_DIR/scripts/setup_redis.sh"
@@ -22,7 +28,7 @@ sudo systemctl enable mariadb
 sudo systemctl start mariadb
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS quant_fund;"
 sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'%' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
-python -m playwright install chromium || true
+python -m playwright install chromium
 
 
 # Register the service

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -81,20 +81,16 @@ async def test_system_checklist(monkeypatch):
 
     monkeypatch.setattr(start_mod, "AlpacaGateway", lambda: DummyGW())
     monkeypatch.setattr(start_mod, "MasterLedger", DummyLedger)
-    await boot.system_checklist()
+    await start_mod.system_checklist()
 
 
-def test_bootstrap_main_order(monkeypatch):
+def test_bootstrap_main(monkeypatch):
     calls = []
-
-    async def fake_checklist():
-        calls.append("checklist")
 
     async def fake_main():
         calls.append("api")
 
-    monkeypatch.setattr(boot, "system_checklist", fake_checklist)
     monkeypatch.setattr(boot, "start_main", fake_main)
 
     boot.main()
-    assert calls == ["checklist", "api"]
+    assert calls == ["api"]


### PR DESCRIPTION
## Summary
- launch FastAPI first and shut it down on bootstrap failure
- streamline bootstrap script to delegate to service.start
- install git/git-lfs and configure backup remote in bootstrap shell script
- adjust bootstrap tests for new startup order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fd193f43c8323ab3bae296649f44e