### PR TITLE
Expose momentum and fundamental data via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,33 @@ endpoints to read the stored records. Risk analytics are surfaced under
 rule management and alert streaming expose nightly computed metrics for each
 strategy.
 
+Portfolio performance queries via `/metrics/{pf_id}` now include win rate and
+annualized volatility for each strategy.
+
 Cross-origin requests are allowed for `GET` endpoints, so a front-end can fetch
 protected resources by appending `?token=` with the API key.
+
+## Alpaca Trading API Endpoints
+
+Front-end components can also interact directly with Alpaca's REST and
+streaming interfaces. Useful routes include:
+
+- `GET /v2/account` – real-time balances
+- `GET /v2/positions` – open positions
+- `GET /v2/orders` and `POST /v2/orders` – recent orders and order entry
+- `GET /v2/account/portfolio/history` – equity curve data
+- `GET /v2/watchlists` and `/v2/watchlists/{id}/assets` – manage watchlists
+- `GET /v2/account/activities` – account activity feed
+- `GET /v2/stocks/{symbol}/bars` – intraday & historical bars
+- `GET /v2/stocks/{symbol}/trades` and `/quotes` – latest trade and quote data
+- `GET /v2/stocks/{symbol}/snapshots` – consolidated symbol snapshot
+- `GET /v2/news` – market news headlines
+- `GET /v2/corporate_actions` – upcoming corporate actions
+- `GET /v2/calendar` – market calendar
+- WebSocket `wss://stream.data.alpaca.markets/v2/iex` – real-time market data
+- WebSocket `wss://stream.alpaca.markets/v2/account` – order and position updates
+- `GET /v2/crypto/{symbol}/bars` and `/snapshots` – crypto price data
+- `GET /v2/forex/{pair}/quotes` – FX rates
 
 ## Monitoring, Testing and Deployment
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Endpoints include a generic `/db/{table}` proxy, portfolio analytics such as
 correlation and sector exposure, and execution helpers for submitting rebalance
 orders. WebSocket feeds publish price ticks, fills and equity updates. Metrics
 are available at `/metrics` and a simple health probe lives at `/health`.
+Momentum and fundamental datasets are exposed through collection routes like
+`/collect/volatility_momentum` and `/collect/fundamentals` with matching `GET`
+endpoints to read the stored records.
+
+Cross-origin requests are allowed for `GET` endpoints, so a front-end can fetch
+protected resources by appending `?token=` with the API key.
 
 ## Monitoring, Testing and Deployment
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ orders. WebSocket feeds publish price ticks, fills and equity updates. Metrics
 are available at `/metrics` and a simple health probe lives at `/health`.
 Momentum and fundamental datasets are exposed through collection routes like
 `/collect/volatility_momentum` and `/collect/fundamentals` with matching `GET`
-endpoints to read the stored records.
+endpoints to read the stored records. Risk analytics are surfaced under
+`/risk/*` where overview, VaR/ES, drawdowns, volatility, beta, correlations,
+rule management and alert streaming expose nightly computed metrics for each
+strategy.
 
 Cross-origin requests are allowed for `GET` endpoints, so a front-end can fetch
 protected resources by appending `?token=` with the API key.

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -356,6 +356,10 @@ lev_sector_coll = db["leveraged_sector_momentum"]
 sector_mom_coll = db["sector_momentum_weekly"]
 smallcap_mom_coll = db["smallcap_momentum_weekly"]
 upgrade_mom_coll = db["upgrade_momentum_weekly"]
+returns_coll = db["returns"]
+risk_stats_coll = db["risk_stats"]
+risk_rules_coll = db["risk_rules"]
+risk_alerts_coll = db["risk_alerts"]
 
 register_db_handler(log_coll)
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -281,3 +281,44 @@ CREATE TABLE IF NOT EXISTS upgrade_momentum_weekly (
     _retrieved TIMESTAMP,
     UNIQUE(symbol, date)
 );
+
+CREATE TABLE IF NOT EXISTS returns (
+    id INTEGER AUTO_INCREMENT PRIMARY KEY,
+    date DATE,
+    strategy VARCHAR(64),
+    return_pct DOUBLE,
+    UNIQUE(date, strategy)
+);
+
+CREATE TABLE IF NOT EXISTS risk_stats (
+    id INTEGER AUTO_INCREMENT PRIMARY KEY,
+    date DATE,
+    strategy VARCHAR(64),
+    var95 DOUBLE,
+    var99 DOUBLE,
+    es95 DOUBLE,
+    es99 DOUBLE,
+    vol30d DOUBLE,
+    beta30d DOUBLE,
+    max_drawdown DOUBLE,
+    UNIQUE(date, strategy)
+);
+
+CREATE TABLE IF NOT EXISTS risk_rules (
+    id INTEGER AUTO_INCREMENT PRIMARY KEY,
+    name TEXT,
+    strategy VARCHAR(64),
+    metric VARCHAR(32),
+    operator VARCHAR(4),
+    threshold DOUBLE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS risk_alerts (
+    id INTEGER AUTO_INCREMENT PRIMARY KEY,
+    rule_id INTEGER REFERENCES risk_rules(id),
+    strategy VARCHAR(64),
+    metric_value DOUBLE,
+    triggered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_acknowledged BOOLEAN DEFAULT FALSE
+);

--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -25,6 +25,10 @@ analysis can reproduce past views of the data.
 | `sector_momentum_weekly` | `symbol`, `date`, `_retrieved` |
 | `smallcap_momentum_weekly` | `symbol`, `date`, `_retrieved` |
 | `upgrade_momentum_weekly` | `symbol`, `date`, `_retrieved` |
+| `returns` | `date`, `strategy`, `return_pct` |
+| `risk_stats` | `date`, `strategy`, `var95`, `var99`, `es95`, `es99`, `vol30d`, `beta30d`, `max_drawdown` |
+| `risk_rules` | `id`, `name`, `strategy`, `metric`, `operator`, `threshold`, `created_at` |
+| `risk_alerts` | `id`, `rule_id`, `strategy`, `metric_value`, `triggered_at`, `is_acknowledged` |
 | `ticker_scores` | `symbol`, `index_name`, `date`, `fundamentals`, `momentum`, `liquidity_sentiment`, `risk_adjusted`, `overall` |
 | `top_scores` | `date`, `symbol`, `index_name`, `score`, `rank` |
 | `portfolios` | `id`, `name`, `weights` |

--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -20,6 +20,11 @@ analysis can reproduce past views of the data.
 | `news_headlines` | `ticker`, `headline`, `link`, `source`, `time`, `_retrieved` |
 | `insider_buying` | `ticker`, `exec`, `shares`, `date`, `_retrieved` |
 | `sp500_index` | `date`, `open`, `high`, `low`, `close`, `volume`, `_retrieved` |
+| `volatility_momentum` | `symbol`, `date`, `_retrieved` |
+| `leveraged_sector_momentum` | `symbol`, `date`, `_retrieved` |
+| `sector_momentum_weekly` | `symbol`, `date`, `_retrieved` |
+| `smallcap_momentum_weekly` | `symbol`, `date`, `_retrieved` |
+| `upgrade_momentum_weekly` | `symbol`, `date`, `_retrieved` |
 | `ticker_scores` | `symbol`, `index_name`, `date`, `fundamentals`, `momentum`, `liquidity_sentiment`, `risk_adjusted`, `overall` |
 | `top_scores` | `date`, `symbol`, `index_name`, `score`, `rank` |
 | `portfolios` | `id`, `name`, `weights` |

--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -34,7 +34,7 @@ analysis can reproduce past views of the data.
 | `portfolios` | `id`, `name`, `weights` |
 | `trades` | `portfolio_id`, `symbol`, `qty`, `side`, `price`, `timestamp` |
 | `weight_history` | `portfolio_id`, `date`, `weights` |
-| `metrics` | `portfolio_id`, `date`, `ret_1d`, `ret_7d`, `ret_30d`, `ret_3m`, `ret_6m`, `ret_1y`, `ret_2y`, `sharpe`, `sortino`, `weekly_vol`, `weekly_sortino`, `alpha`, `beta`, `max_drawdown`, `cagr`, `win_rate`, `information_ratio`, `treynor_ratio`, `var`, `cvar`, `atr_14d`, `rsi_14d` |
+| `metrics` | `portfolio_id`, `date`, `ret_1d`, `ret_7d`, `ret_30d`, `ret_3m`, `ret_6m`, `ret_1y`, `ret_2y`, `sharpe`, `sortino`, `weekly_vol`, `weekly_sortino`, `alpha`, `beta`, `max_drawdown`, `cagr`, `win_rate`, `annual_vol`, `information_ratio`, `treynor_ratio`, `var`, `cvar`, `atr_14d`, `rsi_14d` |
 | `account_metrics_paper` | `id`, `timestamp`, `equity`, `last_equity` |
 | `account_metrics_live` | `id`, `timestamp`, `equity`, `last_equity` |
 | `universe` | `symbol`, `index_name`, `_retrieved` |

--- a/risk/tasks.py
+++ b/risk/tasks.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Background tasks for risk analytics."""
+
+import datetime as dt
+import operator
+from typing import Callable, Dict
+
+import pandas as pd
+
+from database import (
+    returns_coll,
+    risk_stats_coll,
+    risk_rules_coll,
+    risk_alerts_coll,
+    sp500_coll,
+)
+from risk.var import historical_var, cvar
+
+
+def _load_returns(strategy: str, days: int = 60) -> pd.Series:
+    q = {"strategy": strategy}
+    rows = list(returns_coll.find(q).sort("date", -1).limit(days))
+    if not rows:
+        return pd.Series(dtype=float)
+    rows.reverse()
+    dates = [pd.to_datetime(r["date"]) for r in rows]
+    return pd.Series([r["return_pct"] for r in rows], index=dates)
+
+
+def _sp500_returns(days: int = 60) -> pd.Series:
+    rows = list(sp500_coll.find().sort("date", -1).limit(days + 1))
+    if not rows:
+        return pd.Series(dtype=float)
+    rows.sort(key=lambda r: r["date"])
+    closes = pd.Series([r["close"] for r in rows], index=[pd.to_datetime(r["date"]) for r in rows])
+    rets = closes.pct_change().dropna()
+    return rets.tail(days)
+
+
+def compute_risk_stats(days: int = 60) -> None:
+    """Populate ``risk_stats`` table from ``returns``."""
+    if not returns_coll.conn:
+        return
+    with returns_coll.conn.cursor() as cur:
+        cur.execute("SELECT DISTINCT strategy FROM returns")
+        strategies = [r["strategy"] for r in cur.fetchall()]
+    bench = _sp500_returns(days)
+    for strat in strategies:
+        ser = _load_returns(strat, days)
+        if ser.empty:
+            continue
+        var95 = historical_var(ser, 0.95)
+        var99 = historical_var(ser, 0.99)
+        es95 = cvar(ser, 0.95)
+        es99 = cvar(ser, 0.99)
+        vol30 = float(ser.rolling(30).std().iloc[-1]) if len(ser) >= 30 else float(ser.std())
+        beta = float(ser.cov(bench) / bench.var()) if not bench.empty else 0.0
+        cum = (1 + ser).cumprod()
+        peak = cum.cummax()
+        drawdown = (cum / peak - 1).min()
+        risk_stats_coll.update_one(
+            {"strategy": strat, "date": ser.index[-1].date()},
+            {
+                "$set": {
+                    "var95": var95,
+                    "var99": var99,
+                    "es95": es95,
+                    "es99": es99,
+                    "vol30d": vol30,
+                    "beta30d": beta,
+                    "max_drawdown": float(drawdown),
+                }
+            },
+            upsert=True,
+        )
+
+
+def evaluate_risk_rules() -> None:
+    """Evaluate risk rules against latest statistics and log alerts."""
+    if not risk_rules_coll.conn:
+        return
+    rows = list(risk_rules_coll.find())
+    if not rows:
+        return
+    latest_stats: Dict[str, Dict[str, float]] = {}
+    for r in rows:
+        strat = r["strategy"]
+        if strat not in latest_stats:
+            stat = risk_stats_coll.find_one({"strategy": strat}, sort=[("date", -1)])
+            latest_stats[strat] = stat or {}
+        stat = latest_stats[strat]
+        metric_val = stat.get(r["metric"])
+        if metric_val is None:
+            continue
+        op_map: Dict[str, Callable[[float, float], bool]] = {
+            ">": operator.gt,
+            "<": operator.lt,
+            ">=": operator.ge,
+            "<=": operator.le,
+        }
+        func = op_map.get(r["operator"])
+        if func and func(metric_val, r["threshold"]):
+            risk_alerts_coll.insert_many(
+                [
+                    {
+                        "rule_id": r["_id"],
+                        "strategy": strat,
+                        "metric_value": float(metric_val),
+                        "triggered_at": dt.datetime.utcnow(),
+                        "is_acknowledged": False,
+                    }
+                ]
+            )
+
+
+__all__ = ["compute_risk_stats", "evaluate_risk_rules"]

--- a/service/api.py
+++ b/service/api.py
@@ -305,12 +305,17 @@ def get_metrics(pf_id: str, start: Optional[str] = None, end: Optional[str] = No
             "beta",
             "max_drawdown",
             "benchmark",
+            "win_rate",
+            "annual_vol",
             "ret_7d",
             "ret_30d",
             "ret_1y",
         ):
             if k in d:
-                entry[k] = d[k]
+                if k == "annual_vol":
+                    entry["volatility"] = d[k]
+                else:
+                    entry[k] = d[k]
         res.append(entry)
     return {"metrics": res}
 

--- a/service/api.py
+++ b/service/api.py
@@ -642,7 +642,12 @@ async def collect_fundamentals():
 
 @app.get("/top_scores")
 def show_top_scores(limit: int = 20):
-    docs = list(top_score_coll.find().sort([("date", -1), ("rank", 1)]).limit(limit))
+    latest = top_score_coll.find_one(sort=[("date", -1)])
+    if not latest:
+        return {"records": []}
+    docs = list(
+        top_score_coll.find({"date": latest["date"]}).sort("rank", 1).limit(limit)
+    )
     for d in docs:
         d["id"] = str(d.pop("_id"))
     return {"records": docs}

--- a/service/scheduler.py
+++ b/service/scheduler.py
@@ -13,6 +13,7 @@ from database import metric_coll
 from analytics import update_all_metrics, record_account, update_all_ticker_scores
 from scrapers.wallstreetbets import fetch_wsb_mentions
 from scrapers import full_fundamentals
+from risk.tasks import compute_risk_stats, evaluate_risk_rules
 
 _log = get_logger("sched")
 
@@ -126,6 +127,12 @@ class StrategyScheduler:
             **CRON["monthly"],
         )
         self.scheduler.add_job(account_job, "cron", hour=0, minute=0, id="account")
+        self.scheduler.add_job(
+            compute_risk_stats, "cron", hour=0, minute=30, id="risk_stats"
+        )
+        self.scheduler.add_job(
+            evaluate_risk_rules, "cron", minute="*/5", id="risk_rules"
+        )
         self.scheduler.start()
 
     def stop(self):

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+import datetime as dt
+
+from service.api import app, metric_coll
+from service.config import API_TOKEN
+
+client = TestClient(app)
+
+
+def _get(path: str):
+    token = API_TOKEN or ""
+    sep = "&" if "?" in path else "?"
+    return client.get(path + (sep + f"token={token}" if token else ""))
+
+
+def test_metrics_include_win_rate_and_vol(monkeypatch):
+    docs = [
+        {"date": dt.date(2024, 1, 1), "ret": 0.01, "win_rate": 0.6, "annual_vol": 0.2}
+    ]
+
+    class DummyQuery:
+        def __init__(self, docs):
+            self._docs = docs
+
+        def sort(self, field, direction):
+            return self
+
+        def __iter__(self):
+            return iter(self._docs)
+
+    monkeypatch.setattr(metric_coll, "find", lambda q: DummyQuery(docs))
+
+    resp = _get("/metrics/testpf")
+    assert resp.status_code == 200
+    data = resp.json()["metrics"]
+    assert data[0]["win_rate"] == 0.6
+    assert data[0]["volatility"] == 0.2

--- a/tests/test_risk_api.py
+++ b/tests/test_risk_api.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from service.api import app
+from service.config import API_TOKEN
+
+client = TestClient(app)
+
+
+def _get(path: str):
+    token = API_TOKEN or ""
+    sep = "&" if "?" in path else "?"
+    return client.get(path + (sep + f"token={token}" if token else ""))
+
+
+def test_risk_overview_keys():
+    resp = _get("/risk/overview?strategy=dummy")
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ["var95", "vol30d", "maxDrawdown", "beta30d", "alerts"]:
+        assert key in data
+
+
+def test_risk_rules_list():
+    resp = _get("/risk/rules")
+    assert resp.status_code == 200
+    assert "rules" in resp.json()


### PR DESCRIPTION
## Summary
- add collection and retrieval endpoints for all momentum scrapers
- expose full fundamentals and ticker score calculations
- document new database tables and endpoints
- enable GET-only CORS for simple frontend testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe22232cc8323973e12edb2ad5756