### PR TITLE
feat(api): add sorting and field projection to db endpoint

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,21 @@
+# API Reference
+
+## `GET /db/{table}`
+
+Return records from a database collection. Supports pagination, optional field
+projection and sorting.
+
+### Query Parameters
+
+- `limit` – maximum number of records to return (default `50`).
+- `page` – page number for pagination (default `1`).
+- `format` – `json` (default) or `csv` response.
+- `sort_by` – field name used to sort results.
+- `order` – sort direction, `asc` or `desc` (default `asc`).
+- `fields` – comma-separated list of fields to include in the response.
+
+Example:
+
+```
+GET /db/returns?limit=10&sort_by=date&order=desc&fields=date,ret
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,6 @@ This documentation complements the README with details on the scraped data
 and how it is stored.
 
 - [Data Store Format](./data_format.md)
+- [API Reference](./api_reference.md)
 
 Refer to the README for setup and usage instructions.

--- a/service/api.py
+++ b/service/api.py
@@ -353,11 +353,27 @@ def read_table(
     limit: int = 50,
     page: int = 1,
     format: str = "json",
+    sort_by: Optional[str] = None,
+    order: str = "asc",
+    fields: Optional[str] = None,
 ) -> Response | Dict[str, List[Dict[str, Any]]]:
     """Return rows from the requested table with optional pagination."""
     db_ping()
     coll = db[table]
-    qry = coll.find({})
+    projection = None
+    if fields:
+        projection = {
+            f: 1 for f in [fld.strip() for fld in fields.split(",") if fld.strip()]
+        }
+        projection["_id"] = 1
+    qry = coll.find({}, projection)
+    if sort_by:
+        direction = order.lower()
+        if direction not in {"asc", "desc"}:
+            raise HTTPException(400, "invalid order")
+        qry = qry.sort(sort_by, 1 if direction == "asc" else -1)
+    elif order.lower() not in {"asc", "desc"}:
+        raise HTTPException(400, "invalid order")
     if page > 1:
         try:
             qry.offset((page - 1) * limit)
@@ -764,9 +780,7 @@ def risk_overview(strategy: str) -> Dict[str, Any]:
     stat = risk_stats_coll.find_one({"strategy": strategy}, sort=[("date", -1)])
     series = list(risk_stats_coll.find({"strategy": strategy}).sort("date", 1))
     alerts = list(
-        risk_alerts_coll.find({"strategy": strategy})
-        .sort("triggered_at", -1)
-        .limit(20)
+        risk_alerts_coll.find({"strategy": strategy}).sort("triggered_at", -1).limit(20)
     )
     for a in alerts:
         a["triggered_at"] = _iso(a.get("triggered_at"))
@@ -774,15 +788,13 @@ def risk_overview(strategy: str) -> Dict[str, Any]:
         "var95": {
             "current": stat.get("var95") if stat else None,
             "series": [
-                {"date": _iso(r["date"]), "value": r.get("var95")}
-                for r in series
+                {"date": _iso(r["date"]), "value": r.get("var95")} for r in series
             ],
         },
         "vol30d": {
             "current": stat.get("vol30d") if stat else None,
             "series": [
-                {"date": _iso(r["date"]), "value": r.get("vol30d")}
-                for r in series
+                {"date": _iso(r["date"]), "value": r.get("vol30d")} for r in series
             ],
         },
         "maxDrawdown": stat.get("max_drawdown") if stat else None,
@@ -801,12 +813,10 @@ def risk_var(strategy: str, window: int = 30, conf: str = "95,99") -> Dict[str, 
     out: Dict[str, Dict[str, List[Dict[str, Any]]]] = {"var": {}, "es": {}}
     for level in levels:
         out["var"][level] = [
-            {"date": _iso(r["date"]), "value": r.get(f"var{level}")}
-            for r in rows
+            {"date": _iso(r["date"]), "value": r.get(f"var{level}")} for r in rows
         ]
         out["es"][level] = [
-            {"date": _iso(r["date"]), "value": r.get(f"es{level}")}
-            for r in rows
+            {"date": _iso(r["date"]), "value": r.get(f"es{level}")} for r in rows
         ]
     return out
 
@@ -866,10 +876,7 @@ def risk_volatility(strategy: str, window: int = 30) -> Dict[str, Any]:
     )
     rows.reverse()
     return {
-        "series": [
-            {"date": _iso(r["date"]), "value": r.get("vol30d")}
-            for r in rows
-        ]
+        "series": [{"date": _iso(r["date"]), "value": r.get("vol30d")} for r in rows]
     }
 
 
@@ -882,10 +889,7 @@ def risk_beta(
     )
     rows.reverse()
     return {
-        "series": [
-            {"date": _iso(r["date"]), "value": r.get("beta30d")}
-            for r in rows
-        ]
+        "series": [{"date": _iso(r["date"]), "value": r.get("beta30d")} for r in rows]
     }
 
 
@@ -901,9 +905,7 @@ def risk_correlations(items: str, window: int = 30) -> Dict[str, Any]:
         return {"correlations": {}}
     data: Dict[str, List[float]] = {}
     for s in syms:
-        rows = list(
-            returns_coll.find({"strategy": s}).sort("date", -1).limit(window)
-        )
+        rows = list(returns_coll.find({"strategy": s}).sort("date", -1).limit(window))
         rows.reverse()
         data[s] = [r["return_pct"] for r in rows]
     df = pd.DataFrame(data)
@@ -980,9 +982,7 @@ async def ws_risk_alerts(ws: WebSocket) -> None:
     await ws.accept()
     last_id = 0
     while True:
-        rows = list(
-            risk_alerts_coll.find({"_id": {"$gt": last_id}}).sort("_id", 1)
-        )
+        rows = list(risk_alerts_coll.find({"_id": {"$gt": last_id}}).sort("_id", 1))
         for r in rows:
             last_id = max(last_id, r.get("_id", 0))
             if "triggered_at" in r:

--- a/tests/test_read_table_api.py
+++ b/tests/test_read_table_api.py
@@ -1,0 +1,66 @@
+from fastapi.testclient import TestClient
+
+from service import api as api_module
+from service.api import app
+from service.config import API_TOKEN
+
+client = TestClient(app)
+
+
+def _get(path: str):
+    token = API_TOKEN or ""
+    sep = "&" if "?" in path else "?"
+    return client.get(path + (sep + f"token={token}" if token else ""))
+
+
+class DummyCursor:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def sort(self, field, direction):
+        self.docs.sort(key=lambda d: d.get(field), reverse=direction == -1)
+        return self
+
+    def limit(self, n):
+        self.docs = self.docs[:n]
+        return self
+
+    def offset(self, n):
+        self.docs = self.docs[n:]
+        return self
+
+    def __iter__(self):
+        return iter(self.docs)
+
+
+class DummyCollection:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def find(self, query, projection=None):
+        docs = [
+            {k: v for k, v in d.items() if projection is None or k in projection}
+            for d in self._docs
+        ]
+        return DummyCursor(docs)
+
+
+def test_read_table_sort_and_fields(monkeypatch):
+    docs = [{"_id": 1, "a": 2, "b": 3}, {"_id": 2, "a": 1, "b": 4}]
+    monkeypatch.setattr(api_module, "db", {"test": DummyCollection(docs)})
+    monkeypatch.setattr(api_module, "db_ping", lambda: None)
+
+    resp = _get("/db/test?sort_by=a&order=desc&fields=a")
+    assert resp.status_code == 200
+    data = resp.json()["records"]
+    assert data[0]["a"] == 2
+    assert "b" not in data[0]
+    assert "id" in data[0]
+
+
+def test_read_table_invalid_order(monkeypatch):
+    monkeypatch.setattr(api_module, "db", {"test": DummyCollection([])})
+    monkeypatch.setattr(api_module, "db_ping", lambda: None)
+
+    resp = _get("/db/test?order=sideways")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow clients to specify sort_by, order and fields on /db/{table}
- document new parameters and link API reference
- add tests for valid and invalid query options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ef8267c4832392b0ba1574215630