### PR TITLE
Add treasury rate cache and refresh endpoint

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -10,6 +10,7 @@ from .utils import (
     portfolio_correlations,
     sector_exposures,
     ticker_sector,
+    get_treasury_rate,
 )
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "portfolio_correlations",
     "sector_exposures",
     "ticker_sector",
+    "get_treasury_rate",
     "compute_fundamental_metrics",
     "yf_symbol",
 ]

--- a/service/api.py
+++ b/service/api.py
@@ -37,10 +37,12 @@ from core.equity import EquityPortfolio
 from execution.gateway import AlpacaGateway
 from service.config import ALLOW_LIVE
 from service.scheduler import StrategyScheduler
+import analytics.utils as analytics_utils
 from analytics.utils import (
     portfolio_metrics,
     portfolio_correlations,
     sector_exposures,
+    get_treasury_rate,
 )
 from metrics import rebalance_latency
 from analytics import update_all_metrics, update_all_ticker_scores
@@ -110,6 +112,14 @@ async def readyz():
     except Exception as exc:
         return {"status": "fail", "error": str(exc)}
     return {"status": "ready"}
+
+
+@app.get("/refresh/treasury_rate")
+def refresh_treasury_rate() -> Dict[str, Any]:
+    """Force refresh of the cached treasury rate."""
+    rate = get_treasury_rate(force=True)
+    ts = analytics_utils._TREASURY_CACHE["timestamp"].isoformat()
+    return {"rate": rate, "timestamp": ts}
 
 
 # In-memory portfolio objects

--- a/tests/test_treasury_rate.py
+++ b/tests/test_treasury_rate.py
@@ -1,0 +1,51 @@
+import os
+import datetime as dt
+import pandas as pd
+from fastapi.testclient import TestClient
+
+import analytics.utils as utils
+
+
+def _mock_ticker(call_counter):
+    class DummyTicker:
+        def history(self, period="1d"):
+            call_counter[0] += 1
+            return pd.DataFrame({"Close": [5.0]})
+    return DummyTicker
+
+
+def test_treasury_rate_cache(monkeypatch):
+    calls = [0]
+    monkeypatch.setattr(utils.yf, "Ticker", lambda _: _mock_ticker(calls)())
+    utils._TREASURY_CACHE["rate"] = 0.0
+    utils._TREASURY_CACHE["timestamp"] = dt.datetime.fromtimestamp(0)
+
+    rate1 = utils.get_treasury_rate(force=True)
+    rate2 = utils.get_treasury_rate()
+    assert rate1 == rate2 == 0.05
+    assert calls[0] == 1
+
+    utils._TREASURY_CACHE["timestamp"] = dt.datetime.utcnow() - dt.timedelta(days=2)
+    rate3 = utils.get_treasury_rate()
+    assert rate3 == 0.05
+    assert calls[0] == 2
+
+
+def test_refresh_route(monkeypatch):
+    os.environ["API_TOKEN"] = ""
+    calls = [0]
+    monkeypatch.setattr(utils.yf, "Ticker", lambda _: _mock_ticker(calls)())
+    utils._TREASURY_CACHE["rate"] = 0.0
+    utils._TREASURY_CACHE["timestamp"] = dt.datetime.fromtimestamp(0)
+    from importlib import reload
+    import service.config as config
+    import service.api as api
+
+    reload(config)
+    api = reload(api)
+    client = TestClient(api.app)
+
+    resp = client.get("/refresh/treasury_rate")
+    assert resp.status_code == 200
+    assert resp.json()["rate"] == 0.05
+    assert calls[0] == 1


### PR DESCRIPTION
## Summary
- cache 3M treasury bill rate in analytics utils with TTL
- expose cached rate through `/refresh/treasury_rate` endpoint
- cover cache behaviour and refresh route with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ef98f4588323826da37d085b4eb2