### PR TITLE
feat: strategy summary endpoint

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -6,3 +6,23 @@ Key read-only JSON endpoints exposed by the portfolio service.
 - `GET /risk/overview` – Portfolio risk summary including VaR and volatility.
 - `GET /strategies/summary` – Combined weights, metrics, and risk statistics for each strategy.
 
+## `GET /db/{table}`
+
+Return records from a database collection. Supports pagination, optional field
+projection and sorting.
+
+### Query Parameters
+
+- `limit` – maximum number of records to return (default `50`).
+- `page` – page number for pagination (default `1`).
+- `format` – `json` (default) or `csv` response.
+- `sort_by` – field name used to sort results.
+- `order` – sort direction, `asc` or `desc` (default `asc`).
+- `fields` – comma-separated list of fields to include in the response.
+
+Example:
+
+```
+GET /db/returns?limit=10&sort_by=date&order=desc&fields=date,ret
+```
+

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,6 +1,8 @@
 # API Reference
 
-Key read-only JSON endpoints exposed by the portfolio service.
+## Read-only endpoints
+
+The portfolio service exposes the following read-only JSON endpoints:
 
 - `GET /metrics/{pf_id}` – Latest performance metrics for a given strategy.
 - `GET /risk/overview` – Portfolio risk summary including VaR and volatility.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,8 @@
+# API Reference
+
+Key read-only JSON endpoints exposed by the portfolio service.
+
+- `GET /metrics/{pf_id}` – Latest performance metrics for a given strategy.
+- `GET /risk/overview` – Portfolio risk summary including VaR and volatility.
+- `GET /strategies/summary` – Combined weights, metrics, and risk statistics for each strategy.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ This documentation complements the README with details on the scraped data
 and how it is stored.
 
 - [Data Store Format](./data_format.md)
+- [API Reference](./api_reference.md)
 - [Strategy Summary API](./strategy_summary.md)
 
 Refer to the README for setup and usage instructions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 # Portfolio Allocation System
 
-This documentation complements the README with details on the scraped data
-and how it is stored.
+This documentation complements the README with details on the scraped data and how it is stored. Browse the sections below for deeper explanations and API usage.
 
 - [Data Store Format](./data_format.md)
 - [API Reference](./api_reference.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,6 @@ This documentation complements the README with details on the scraped data
 and how it is stored.
 
 - [Data Store Format](./data_format.md)
+- [Strategy Summary API](./strategy_summary.md)
 
 Refer to the README for setup and usage instructions.

--- a/docs/strategy_summary.md
+++ b/docs/strategy_summary.md
@@ -1,0 +1,20 @@
+# Strategy Summary API
+
+`GET /strategies/summary` aggregates the latest metrics, risk statistics and weights
+for every strategy.
+
+Example response:
+
+```json
+{
+  "strategies": [
+    {
+      "id": "pf1",
+      "name": "Momentum",
+      "weights": {"AAPL": 0.5, "MSFT": 0.5},
+      "metrics": {"date": "2024-01-01", "ret": 0.02},
+      "risk": {"date": "2024-01-01", "var95": -0.05, "vol30d": 0.12}
+    }
+  ]
+}
+```

--- a/service/api.py
+++ b/service/api.py
@@ -200,8 +200,14 @@ def strategies_summary() -> Dict[str, Any]:
     res: List[Dict[str, Any]] = []
     for d in docs:
         pf_id = str(d.get("_id"))
-        metrics = metric_coll.find_one({"portfolio_id": pf_id}, sort=[("date", -1)]) or {}
-        risk = risk_stats_coll.find_one({"strategy": pf_id}, sort=[("date", -1)]) or {}
+        metric_doc = (
+            metric_coll.find_one({"portfolio_id": pf_id}, sort=[("date", -1)])
+            or {}
+        )
+        risk_doc = (
+            risk_stats_coll.find_one({"strategy": pf_id}, sort=[("date", -1)])
+            or {}
+        )
         res.append(
             {
                 "id": pf_id,
@@ -209,12 +215,12 @@ def strategies_summary() -> Dict[str, Any]:
                 "weights": d.get("weights", {}),
                 "metrics": {
                     k: _iso(v) if k == "date" else v
-                    for k, v in metrics.items()
+                    for k, v in metric_doc.items()
                     if k not in {"_id", "portfolio_id"}
                 },
                 "risk": {
                     k: _iso(v) if k == "date" else v
-                    for k, v in risk.items()
+                    for k, v in risk_doc.items()
                     if k not in {"_id", "strategy"}
                 },
             }

--- a/tests/test_strategy_summary_api.py
+++ b/tests/test_strategy_summary_api.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+import datetime as dt
+
+from service.api import app, pf_coll, metric_coll, risk_stats_coll
+from service.config import API_TOKEN
+
+client = TestClient(app)
+
+
+def _get(path: str):
+    token = API_TOKEN or ""
+    sep = "&" if "?" in path else "?"
+    return client.get(path + (sep + f"token={token}" if token else ""))
+
+
+def test_strategy_summary_aggregates(monkeypatch):
+    portfolios = [{"_id": "pf1", "name": "P1", "weights": {"AAPL": 0.5}}]
+
+    monkeypatch.setattr(pf_coll, "find", lambda *a, **k: portfolios)
+
+    def fake_metric(q, sort=None):
+        return {"date": dt.date(2024, 1, 1), "ret": 0.1, "portfolio_id": q["portfolio_id"]}
+
+    def fake_risk(q, sort=None):
+        return {"date": dt.date(2024, 1, 1), "var95": -0.05, "strategy": q["strategy"]}
+
+    monkeypatch.setattr(metric_coll, "find_one", fake_metric)
+    monkeypatch.setattr(risk_stats_coll, "find_one", fake_risk)
+
+    resp = _get("/strategies/summary")
+    assert resp.status_code == 200
+    data = resp.json()["strategies"][0]
+    assert data["metrics"]["ret"] == 0.1
+    assert data["risk"]["var95"] == -0.05
+    assert data["weights"] == {"AAPL": 0.5}


### PR DESCRIPTION
## Summary
- add `/strategies/summary` API route that aggregates portfolio weights with latest metrics and risk statistics
- document the new strategy summary endpoint
- test the aggregated response payload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ef94fb1883239c761cf48d6ffe10