### PR TITLE
feat: add dashboard metrics

### DIFF
--- a/analytics/tracking.py
+++ b/analytics/tracking.py
@@ -16,7 +16,7 @@ from database import (
     top_score_coll,
     weight_coll,
 )
-from analytics.utils import portfolio_metrics
+from analytics.utils import portfolio_metrics, record_daily_metrics
 from scrapers.universe import load_sp500, load_sp400, load_russell2000
 from analytics.fundamentals import compute_fundamental_metrics, yf_symbol
 import numpy as np
@@ -79,6 +79,7 @@ def update_all_metrics(days: int = 90) -> None:
             {"$set": metrics},
             upsert=True,
         )
+        record_daily_metrics(pf_id, series, weights)
         csv_dir = Path("cache") / "metrics"
         csv_dir.mkdir(parents=True, exist_ok=True)
         csv_path = csv_dir / f"{pf_id}.csv"

--- a/service/static/dashboard.html
+++ b/service/static/dashboard.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Portfolio Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="/static/dashboard.js" defer></script>
+</head>
+<body>
+  <h1>Portfolio Dashboard</h1>
+  <div>
+    <canvas id="returnsChart"></canvas>
+    <button id="exportReturns">Export CSV</button>
+    <button id="downloadReturns">Download PNG</button>
+  </div>
+  <div>
+    <canvas id="exposureChart"></canvas>
+    <button id="downloadExposure">Download PNG</button>
+  </div>
+  <div>
+    Alpha: <span id="alpha"></span> Beta: <span id="beta"></span>
+  </div>
+</body>
+</html>

--- a/service/static/dashboard.js
+++ b/service/static/dashboard.js
@@ -1,0 +1,52 @@
+async function loadDashboard() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const pfId = urlParams.get('pf_id') || '';
+  if (!pfId) return;
+  const resp = await fetch(`/dashboard/${pfId}`);
+  const data = await resp.json();
+
+  const dates = data.returns.map(r => r.date);
+  const vals = data.returns.map(r => r.value);
+  const returnsCtx = document.getElementById('returnsChart').getContext('2d');
+  const returnsChart = new Chart(returnsCtx, {
+    type: 'line',
+    data: { labels: dates, datasets: [{ label: 'Returns', data: vals }] }
+  });
+
+  document.getElementById('downloadReturns').onclick = () => {
+    const a = document.createElement('a');
+    a.href = returnsChart.toBase64Image();
+    a.download = 'returns.png';
+    a.click();
+  };
+
+  document.getElementById('exportReturns').onclick = () => {
+    let csv = 'date,return\n';
+    data.returns.forEach(r => { csv += `${r.date},${r.value}\n`; });
+    const blob = new Blob([csv], {type: 'text/csv'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'returns.csv';
+    a.click();
+  };
+
+  const expLabels = Object.keys(data.exposures);
+  const expVals = Object.values(data.exposures);
+  const expCtx = document.getElementById('exposureChart').getContext('2d');
+  const exposureChart = new Chart(expCtx, {
+    type: 'pie',
+    data: { labels: expLabels, datasets: [{ data: expVals }] }
+  });
+
+  document.getElementById('downloadExposure').onclick = () => {
+    const a = document.createElement('a');
+    a.href = exposureChart.toBase64Image();
+    a.download = 'exposures.png';
+    a.click();
+  };
+
+  document.getElementById('alpha').textContent = data.alpha !== null && data.alpha !== undefined ? data.alpha.toFixed(4) : '';
+  document.getElementById('beta').textContent = data.beta !== null && data.beta !== undefined ? data.beta.toFixed(4) : '';
+}
+
+window.addEventListener('load', loadDashboard);

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+import datetime as dt
+from fastapi.testclient import TestClient
+
+from service.api import app, returns_coll, metric_coll
+from service.config import API_TOKEN
+
+client = TestClient(app)
+
+
+def _get(path: str):
+    token = API_TOKEN or ""
+    sep = "&" if "?" in path else "?"
+    return client.get(path + (sep + f"token={token}" if token else ""))
+
+
+def test_dashboard_endpoint(monkeypatch):
+    returns_docs = [
+        {"date": dt.date(2024, 1, 1), "return_pct": 0.01},
+        {"date": dt.date(2024, 1, 2), "return_pct": -0.02},
+    ]
+
+    class DummyQuery:
+        def __init__(self, docs):
+            self._docs = docs
+
+        def sort(self, field, direction):
+            return self
+
+        def limit(self, n):
+            return self
+
+        def __iter__(self):
+            return iter(self._docs)
+
+    monkeypatch.setattr(returns_coll, "find", lambda q: DummyQuery(returns_docs))
+    monkeypatch.setattr(
+        metric_coll,
+        "find_one",
+        lambda q, sort=None: {"exposures": {"Tech": 0.7}, "alpha": 0.1, "beta": 1.2},
+    )
+
+    resp = _get("/dashboard/pf1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["returns"][0]["value"] == 0.01
+    assert data["exposures"]["Tech"] == 0.7
+    assert data["alpha"] == 0.1
+    assert data["beta"] == 1.2

--- a/tests/test_record_daily_metrics.py
+++ b/tests/test_record_daily_metrics.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+from analytics import utils
+
+
+def test_record_daily_metrics(monkeypatch):
+    series = pd.Series([0.01, -0.02], index=pd.to_datetime(["2024-01-01", "2024-01-02"]))
+    weights = {"AAA": 0.6, "BBB": 0.4}
+
+    returns_docs = []
+    metrics_docs = []
+
+    class DummyReturns:
+        conn = True
+
+        def update_one(self, match, update, upsert=False):
+            doc = {**match, **update["$set"]}
+            returns_docs.append(doc)
+
+    class DummyMetrics:
+        def update_one(self, match, update, upsert=False):
+            doc = {**match, **update["$set"]}
+            metrics_docs.append(doc)
+
+    monkeypatch.setattr(utils, "returns_coll", DummyReturns())
+    monkeypatch.setattr(utils, "metric_coll", DummyMetrics())
+    monkeypatch.setattr(utils, "ticker_sector", lambda sym: "Tech" if sym == "AAA" else "Finance")
+
+    utils.record_daily_metrics("pf1", series, weights)
+
+    assert len(returns_docs) == 2
+    assert any(d["return_pct"] == -0.02 for d in returns_docs)
+    assert metrics_docs[0]["exposures"]["Tech"] == 0.6
+    assert metrics_docs[0]["exposures"]["Finance"] == 0.4


### PR DESCRIPTION
## Summary
- persist portfolio returns and sector exposures
- expose dashboard JSON endpoint and static assets
- render interactive charts with export options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911843ef5c8323aec80ebc67ee3ff4