### PR TITLE
Broadcast metric and log events

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,7 @@ This documentation complements the README with details on the scraped data
 and how it is stored.
 
 - [Data Store Format](./data_format.md)
+- [WebSocket Protocol](./websocket.md)
+- [API Reference](./api_reference.md)
 
 Refer to the README for setup and usage instructions.

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,27 @@
+# WebSocket Protocol
+
+The API exposes a `/ws` endpoint that streams events to connected clients.
+
+Clients connect using the standard WebSocket handshake:
+
+```
+ws://<host>:<port>/ws
+```
+
+Each message is a JSON-formatted string with a `type` field identifying the
+payload. Current message types include:
+
+- `metric` – portfolio metrics updated via the `/metrics/{pf_id}` endpoint.
+- `system_log` – new system log entries posted through the `/logs` endpoint.
+
+Example payloads:
+
+```json
+{"type": "metric", "portfolio_id": "demo", "metrics": {"ret": 0.01}}
+```
+
+```json
+{"type": "system_log", "message": "scheduler started", "timestamp": "2024-01-01T00:00:00"}
+```
+
+Clients should parse the JSON and branch on the `type` to handle new events.

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -1,3 +1,3 @@
-from .hub import router as ws_router
+from .hub import broadcast_message, router as ws_router
 
-__all__ = ["ws_router"]
+__all__ = ["ws_router", "broadcast_message"]


### PR DESCRIPTION
## Summary
- add broadcast_message helper in WebSocket hub and re-export
- push metric and log updates to WebSocket clients
- document WebSocket payloads and reference from docs index
- send WebSocket broadcasts concurrently to avoid slow clients blocking others

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ef82af8083238a07f33784d97c7b