### PR TITLE
Fix momentum scraper startup

### DIFF
--- a/scrapers/leveraged_sector_momentum.py
+++ b/scrapers/leveraged_sector_momentum.py
@@ -26,7 +26,10 @@ def fetch_leveraged_sector_summary(weeks: int = 13) -> List[dict]:
             scrape_errors.labels("leveraged_sector_momentum").inc()
             log.exception("leveraged batch failed: %s", exc)
             return []
-        ret = px.iloc[-1] / px.iloc[-weeks] - 1
+        if len(px) < weeks + 1:
+            log.warning("leveraged sector insufficient rows (%d)", len(px))
+            return []
+        ret = px.iloc[-1] / px.iloc[-(weeks + 1)] - 1
         top = ret.sort_values(ascending=False).head(_LEV_N)
         rows: List[dict] = []
         lev_sector_coll.delete_many({"date": end})

--- a/scrapers/sector_momentum.py
+++ b/scrapers/sector_momentum.py
@@ -26,7 +26,10 @@ def fetch_sector_momentum_summary(weeks: int = 26) -> List[dict]:
             scrape_errors.labels("sector_momentum_weekly").inc()
             log.exception("sector batch failed: %s", exc)
             return []
-        ret = px.iloc[-1] / px.iloc[-weeks] - 1
+        if len(px) < weeks + 1:
+            log.warning("sector momentum insufficient rows (%d)", len(px))
+            return []
+        ret = px.iloc[-1] / px.iloc[-(weeks + 1)] - 1
         top = ret.sort_values(ascending=False).head(_SECTOR_N)
         rows: List[dict] = []
         sector_mom_coll.delete_many({"date": end})

--- a/scrapers/smallcap_momentum.py
+++ b/scrapers/smallcap_momentum.py
@@ -35,8 +35,13 @@ def fetch_smallcap_momentum_summary(
                 scrape_errors.labels("smallcap_momentum_weekly").inc()
                 log.exception("smallcap batch %s failed: %s", batch[:3], exc)
                 continue
+            if len(px) < weeks + 1:
+                log.warning(
+                    "smallcap batch %s insufficient rows (%d)", batch[:3], len(px)
+                )
+                continue
             last = px.iloc[-1]
-            ret = px.iloc[-1] / px.iloc[-weeks] - 1
+            ret = px.iloc[-1] / px.iloc[-(weeks + 1)] - 1
             df = pd.DataFrame({"price": last, "ret": ret})
             rets.append(df)
     if not rets:

--- a/scrapers/upgrade_momentum.py
+++ b/scrapers/upgrade_momentum.py
@@ -31,6 +31,9 @@ async def fetch_upgrade_momentum_summary(
             scrape_errors.labels("upgrade_momentum_weekly").inc()
             log.exception("upgrade fetch failed: %s", exc)
             return []
+        if df.empty:
+            log.warning("upgrade momentum returned no data")
+            return []
         df["ratio"] = (df["upgrades"] - df["downgrades"]) / df["total"].replace(
             0, math.nan
         )

--- a/scrapers/volatility_momentum.py
+++ b/scrapers/volatility_momentum.py
@@ -42,6 +42,9 @@ def fetch_volatility_momentum_summary(weeks: int = 52) -> List[dict]:
                 scrape_errors.labels("volatility_momentum").inc()
                 log.exception("vol batch %s failed: %s", batch[:3], exc)
                 continue
+            if len(px) < weeks + 1:
+                log.warning("vol batch %s insufficient rows (%d)", batch[:3], len(px))
+                continue
             df = _score_vol_mom(px)
             score_frames.append(df)
     if not score_frames:

--- a/scripts/populate.py
+++ b/scripts/populate.py
@@ -131,7 +131,10 @@ async def run_scrapers(force: bool = False) -> None:
                     val = next(iter(data.values()))
                     if isinstance(val, dict):
                         cols = len(val)
-            _log.info(f"{name} PASS {rows}x{cols}")
+            if rows == 0:
+                _log.warning(f"{name} produced no rows")
+            else:
+                _log.info(f"{name} PASS {rows}x{cols}")
         except Exception as exc:
             _log.exception(f"{name} FAIL: {exc}")
 

--- a/service/scheduler.py
+++ b/service/scheduler.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import asyncio
 import threading
+import logging
 import pandas as pd
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -31,6 +32,7 @@ from scrapers.upgrade_momentum import fetch_upgrade_momentum_summary
 from risk.tasks import compute_risk_stats, evaluate_risk_rules
 
 _log = get_logger("sched")
+logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
 
 class StrategyScheduler:


### PR DESCRIPTION
## Summary
- guard against missing price history in momentum scrapers
- warn when scrapers return no rows and silence APScheduler success logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974d3e3dec8323a30e4026d1dca814