### PR TITLE
Parameterize momentum scrapers for limited runs

### DIFF
--- a/scrapers/analyst_ratings.py
+++ b/scrapers/analyst_ratings.py
@@ -270,7 +270,7 @@ async def fetch_analyst_ratings(limit: int = 15) -> List[dict]:
 
 
 async def fetch_changes(symbols: Iterable[str], weeks: int = 4) -> pd.DataFrame:
-    cutoff = pd.Timestamp.today(tz=dt.timezone.utc) - pd.Timedelta(weeks=weeks)
+    cutoff = pd.Timestamp.today() - pd.Timedelta(weeks=weeks)
     all_records = await fetch_analyst_ratings(limit=200)
     df = pd.DataFrame(all_records)
     if df.empty:
@@ -284,7 +284,7 @@ async def fetch_changes(symbols: Iterable[str], weeks: int = 4) -> pd.DataFrame:
                 "numAnalystOpinions",
             ]
         )
-    df["date"] = pd.to_datetime(df["date_utc"], errors="coerce")
+    df["date"] = pd.to_datetime(df["date_utc"], errors="coerce").dt.tz_localize(None)
     df = df.dropna(subset=["date"])
     df = df[df["date"] >= cutoff]
     rows: List[dict] = []

--- a/scrapers/momentum_common.py
+++ b/scrapers/momentum_common.py
@@ -26,7 +26,7 @@ def _weekly_closes(tickers: list[str], weeks: int) -> pd.DataFrame:
         start=start,
         end=end + dt.timedelta(days=1),
         interval="1wk",
-        group_by="ticker",
+        group_by="column",
         threads=True,
         progress=False,
     )


### PR DESCRIPTION
## Summary
- Allow top-N and universe limits across all momentum scrapers
- Normalize analyst rating timestamps to avoid tz comparison failures
- Cover momentum scrapers with unit tests mocking 5-row data

## Testing
- `pytest -q`
- `python -m scrapers.sector_momentum`
- `python -m scrapers.leveraged_sector_momentum`
- `python - <<'PY'...` (smallcap_momentum with sample tickers)
- `python - <<'PY'...` (upgrade_momentum with sample tickers)
- `python - <<'PY'...` (volatility_momentum with patched universe)


------
https://chatgpt.com/codex/tasks/task_e_689c505e1bc08323bafb2a7d9adb05b1