### PR TITLE
Fix FastAPI bootstrap race and add momentum logs

### DIFF
--- a/scrapers/leveraged_sector_momentum.py
+++ b/scrapers/leveraged_sector_momentum.py
@@ -34,6 +34,9 @@ def fetch_leveraged_sector_summary(
         Number of ETFs to keep.  Exposing this allows callers to limit rows
         during testing.
     """
+    log.info(
+        "fetch_leveraged_sector_summary start weeks=%d top_n=%d", weeks, top_n
+    )
     init_db()
     end = dt.date.today()
     now = dt.datetime.now(dt.timezone.utc)

--- a/scrapers/sector_momentum.py
+++ b/scrapers/sector_momentum.py
@@ -33,6 +33,9 @@ def fetch_sector_momentum_summary(weeks: int = 26, top_n: int = _SECTOR_N) -> Li
         result keeps test runs lightweight and satisfies the requirement to
         collect only a handful of rows.
     """
+    log.info(
+        "fetch_sector_momentum_summary start weeks=%d top_n=%d", weeks, top_n
+    )
     init_db()
     end = dt.date.today()
     now = dt.datetime.now(dt.timezone.utc)

--- a/scrapers/smallcap_momentum.py
+++ b/scrapers/smallcap_momentum.py
@@ -43,6 +43,12 @@ def fetch_smallcap_momentum_summary(
         keeps test runs fast and avoids large downloads when a full Russell 2000
         list is supplied.
     """
+    log.info(
+        "fetch_smallcap_momentum_summary start weeks=%d top_n=%d max_tickers=%s",
+        weeks,
+        top_n,
+        max_tickers,
+    )
     symbols = list(tickers)
     if max_tickers is not None:
         symbols = symbols[:max_tickers]

--- a/scrapers/upgrade_momentum.py
+++ b/scrapers/upgrade_momentum.py
@@ -41,6 +41,12 @@ async def fetch_upgrade_momentum_summary(
         Optional cap on how many symbols are queried.  Limiting the universe
         keeps calls to the QuiverQuant API small during tests.
     """
+    log.info(
+        "fetch_upgrade_momentum_summary start weeks=%d top_n=%d max_symbols=%s",
+        weeks,
+        top_n,
+        max_symbols,
+    )
     symbols = list(universe)
     if max_symbols is not None:
         symbols = symbols[:max_symbols]

--- a/scrapers/volatility_momentum.py
+++ b/scrapers/volatility_momentum.py
@@ -49,6 +49,12 @@ def fetch_volatility_momentum_summary(
     max_tickers: int | None = None,
 ) -> List[dict]:
     """Store volatility-scaled momentum scores for the full universe."""
+    log.info(
+        "fetch_volatility_momentum_summary start weeks=%d top_n=%d max_tickers=%s",
+        weeks,
+        top_n,
+        max_tickers,
+    )
     universe_df = load_universe_any()
     tickers = _tickers_from_universe(universe_df)
     if max_tickers is not None:

--- a/service/start.py
+++ b/service/start.py
@@ -89,45 +89,37 @@ async def system_checklist() -> None:
     log.info("system checklist complete")
 
 
-async def _launch_server(host: str, port: int) -> tuple[uvicorn.Server, asyncio.Task]:
-    """Start the FastAPI server and return the server and its task."""
+async def _launch_server(host: str, port: int) -> None:
+    """Start the FastAPI server and block until shutdown."""
     config = uvicorn.Config("service.api:app", host=host, port=port)
     server = uvicorn.Server(config)
     task = asyncio.create_task(server.serve())
     while not server.started:
         await asyncio.sleep(0.1)
     log.info(f"api server running on http://{host}:{port}")
-    return server, task
+    await task
 
 
 async def main(host: str | None = None, port: int | None = None) -> None:
-    """Launch the API first, then run setup tasks and scrapers."""
+    """Run startup tasks and then launch the API server."""
     log.info("startup sequence begin")
 
-    h = host or API_HOST or "192.168.0.59"
+    h = host or API_HOST or "0.0.0.0"
     p = port or API_PORT or 8001
-    server, task = await _launch_server(h, p)
 
-    try:
-        log.info("validate config")
-        validate_config()
-        log.info("connectivity checks")
-        await system_checklist()
-        log.info("initialising database")
-        init_db()
-        log.info("loading portfolios")
-        load_portfolios()
-        # Scheduler is started during FastAPI's startup event
-        log.info("running scrapers")
-        await run_scrapers(force=True)
-    except Exception as exc:  # pragma: no cover - startup errors
-        log.exception(f"fatal startup error: {exc}")
-        server.should_exit = True
-        await task
-        raise
-
-    log.info("system up and running")
-    await task
+    log.info("validate config")
+    validate_config()
+    log.info("connectivity checks")
+    await system_checklist()
+    log.info("initialising database")
+    init_db()
+    log.info("loading portfolios")
+    load_portfolios()
+    # Scheduler is started during FastAPI's startup event
+    log.info("running scrapers")
+    await run_scrapers(force=True)
+    log.info("launching api server")
+    await _launch_server(h, p)
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -111,11 +111,7 @@ async def test_bootstrap_runs_momentum_scrapers(monkeypatch):
     calls: list[str] = []
 
     async def fake_launch_server(*_a, **_k):
-        class DummyServer:
-            started = True
-            should_exit = False
-
-        return DummyServer(), asyncio.create_task(asyncio.sleep(0))
+        calls.append("api")
 
     monkeypatch.setattr(start_mod, "_launch_server", fake_launch_server)
     monkeypatch.setattr(start_mod, "validate_config", lambda: None)
@@ -175,4 +171,4 @@ async def test_bootstrap_runs_momentum_scrapers(monkeypatch):
     monkeypatch.setattr(pop, "update_all_ticker_scores", lambda: None)
 
     await start_mod.main("x", 0)
-    assert {"vol", "lev", "sec", "small", "up"} <= set(calls)
+    assert {"vol", "lev", "sec", "small", "up", "api"} <= set(calls)


### PR DESCRIPTION
## Summary
- launch FastAPI only after config checks and scrapers finish
- add startup logs to all momentum scrapers
- test bootstrap runs momentum scrapers and uvicorn, plus weekly close fetch logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e3c05c728832394e072275eac67a8