### PR TITLE
Add SEC EDGAR fallback for fundamentals

### DIFF
--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -74,4 +74,10 @@ across the entire universe and applying the weights listed in the README.
 The `top_scores` table archives the highest ranked names after each monthly update.
 Fundamental ratios like the Piotroski F‑Score, Altman Z‑Score, ROIC and
 Free Cash Flow Yield are computed entirely from Yahoo Finance statements.
-`weight_history` simply records the raw weight vector for each portfolio.
+When Yahoo blocks access the scraper falls back to the SEC EDGAR
+``companyfacts`` endpoint, pulling ``CashAndCashEquivalentsAtCarryingValue``
+as ``totalCash``, ``Debt`` as ``totalDebt`` and
+``CommonStockSharesOutstanding`` as ``sharesOutstanding``. Requests include a
+modern ``User-Agent`` header and are delayed 0.2–0.5 s to respect SEC rate
+limits. `weight_history` simply records the raw weight vector for each
+portfolio.

--- a/scrapers/edgar.py
+++ b/scrapers/edgar.py
@@ -1,0 +1,90 @@
+import random
+import time
+from typing import Dict, Optional
+
+import requests
+
+from service.logger import get_scraper_logger
+
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124 Safari/537.36"
+)
+
+session = requests.Session()
+session.headers.update({"User-Agent": UA})
+
+log = get_scraper_logger(__name__)
+
+BASE = "https://data.sec.gov/api/xbrl"
+
+_CIK_CACHE: dict[str, int] = {}
+
+
+def _sleep():
+    time.sleep(0.2 + random.random() * 0.3)
+
+
+def _ticker_to_cik(symbol: str) -> Optional[int]:
+    sym = symbol.lower()
+    if sym in _CIK_CACHE:
+        return _CIK_CACHE[sym]
+    try:
+        _sleep()
+        resp = session.get(f"{BASE}/ticker/{sym}.json", timeout=10)
+        if resp.status_code != 200:
+            return None
+        cik = int(resp.json().get("cik_str"))
+        _CIK_CACHE[sym] = cik
+        return cik
+    except Exception:
+        log.warning("edgar cik lookup failed for %s", symbol)
+        return None
+
+
+def _latest_fact(facts: dict, *names: str) -> Optional[float]:
+    for name in names:
+        node = facts.get(name)
+        if not node or "units" not in node:
+            continue
+        units = next(iter(node["units"].values()), [])
+        if units:
+            val = units[-1].get("val")
+            if val is not None:
+                return float(val)
+    return None
+
+
+def fetch_edgar_facts(symbol: str) -> Dict[str, float]:
+    """Return a minimal fundamentals dict from SEC EDGAR."""
+    cik = _ticker_to_cik(symbol)
+    if not cik:
+        return {}
+    try:
+        _sleep()
+        resp = session.get(f"{BASE}/companyfacts/CIK{cik:010d}.json", timeout=10)
+        if resp.status_code != 200:
+            return {}
+        data = resp.json()
+    except Exception:
+        log.warning("edgar facts fetch failed for %s", symbol)
+        return {}
+    facts = data.get("facts", {})
+    out: Dict[str, float] = {}
+    cash = _latest_fact(facts, "CashAndCashEquivalentsAtCarryingValue")
+    if cash is not None:
+        out["totalCash"] = cash
+    debt = _latest_fact(facts, "Debt", "LongTermDebt")
+    if debt is not None:
+        out["totalDebt"] = debt
+    shares = _latest_fact(
+        facts,
+        "CommonStockSharesOutstanding",
+        "EntityCommonStockSharesOutstanding",
+    )
+    if shares is not None:
+        out["sharesOutstanding"] = shares
+    return out
+
+
+__all__ = ["fetch_edgar_facts"]

--- a/scrapers/edgar.py
+++ b/scrapers/edgar.py
@@ -1,6 +1,6 @@
 import random
 import time
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -47,7 +47,7 @@ def _latest_fact(facts: dict, *names: str) -> Optional[float]:
         node = facts.get(name)
         if not node or "units" not in node:
             continue
-        units = next(iter(node["units"].values()), [])
+        units: list[dict[str, Any]] = next(iter(node["units"].values()), [])
         if units:
             val = units[-1].get("val")
             if val is not None:

--- a/scrapers/full_fundamentals.py
+++ b/scrapers/full_fundamentals.py
@@ -18,8 +18,16 @@ import datetime as dt
 import warnings
 from typing import List, Sequence, Dict, Iterable, Tuple
 import time
+import random
+
+import requests
+try:  # yfinance may use curl_cffi under the hood
+    from curl_cffi.requests.exceptions import HTTPError
+except Exception:  # fallback to standard requests
+    from requests.exceptions import HTTPError
 
 from scrapers.universe import load_sp500, load_sp400, load_russell2000
+from scrapers.edgar import fetch_edgar_facts
 from database import init_db, top_score_coll
 from infra.github_backup import backup_records
 from service.logger import get_scraper_logger
@@ -29,6 +37,19 @@ import pandas as pd
 import yfinance as yf
 
 log = get_scraper_logger(__name__)
+
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124 Safari/537.36"
+)
+session = requests.Session()
+session.headers.update(
+    {
+        "User-Agent": UA,
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept": "application/json, text/plain, */*",
+    }
+)
 
 PRICE_LOOKBACK_DAYS = 400
 POSITION_DOLLARS = 5_000_000
@@ -120,6 +141,38 @@ def gv(df, aliases: Sequence[str], idx: int, default=np.nan):
     return default
 
 
+def fetch_fundamentals(symbol: str) -> Dict[str, float]:
+    """Return fundamentals for ``symbol`` with retries and fallbacks.
+
+    Attempts the heavier :meth:`yfinance.Ticker.get_info` call once and, on
+    common HTTP errors, retries after a short backoff.  If that fails, fall back
+    to the lighter ``fast_info`` payload.  Returns an empty dict if all attempts
+    fail so callers can decide how to handle missing data.
+    """
+
+    t = yf.Ticker(symbol, session=session)
+    for delay in (0.5, 1.0):
+        try:
+            return t.get_info()
+        except HTTPError as e:  # pragma: no cover - network conditions vary
+            msg = str(e)
+            if any(code in msg for code in ("401", "403", "429")):
+                time.sleep(delay + random.random())
+                continue
+            raise
+        except Exception:
+            break
+
+    try:  # fall back to lightweight fast_info
+        fi = t.fast_info
+        data = {k: getattr(fi, k) for k in dir(fi) if not k.startswith("_")}
+        if data:
+            return data
+    except Exception:
+        pass
+    return fetch_edgar_facts(symbol)
+
+
 def pct_change_price(series: pd.Series, periods: int):
     if len(series) < periods + 1:
         return np.nan
@@ -180,7 +233,7 @@ def download_prices_batch(
 
 def previous_shares_outstanding(ticker: str):
     try:
-        tk = yf.Ticker(ticker)
+        tk = yf.Ticker(ticker, session=session)
         hist = tk.get_shares_full(start=dt.date.today() - dt.timedelta(days=500))
         if hist is not None and not hist.empty:
             hist = hist.sort_index()
@@ -377,11 +430,14 @@ def collect_fundamentals(ticker: str):
     backoff = INFO_BACKOFF_SEC
     for attempt in range(1, INFO_RETRIES + 1):
         try:
-            tk = yf.Ticker(ticker)
+            tk = yf.Ticker(ticker, session=session)
             fin = last_two(tk.financials)
             bs = last_two(tk.balance_sheet)
             cf = last_two(tk.cashflow)
-            info = tk.info
+            info = fetch_fundamentals(ticker)
+            if not info:
+                log.warning("collect_fundamentals skip %s: no fundamentals", ticker)
+                return {}
             break
         except Exception as exc:
             if attempt == INFO_RETRIES:
@@ -481,7 +537,7 @@ def build_price_metrics(
                         (recent["High"] - recent["Low"]) / recent["Close"]
                     ).mean()
                     avg_vol = recent["Volume"].mean()
-                    info = yf.Ticker(t).info
+                    info = fetch_fundamentals(t)
                     shares = info.get("sharesOutstanding")
                     insider = info.get("heldPercentInsiders") or 0.0
                     float_shares = shares * (1 - insider) if shares else np.nan
@@ -777,7 +833,7 @@ def build_fundamentals(universe: Iterable[str]) -> pd.DataFrame:
         data["ticker"] = t
         rows.append(data)
         if TICKER_SLEEP_SEC and i + 1 < len(tickers):
-            time.sleep(TICKER_SLEEP_SEC)
+            time.sleep(TICKER_SLEEP_SEC + random.random() * 0.3)
     return pd.DataFrame(rows).set_index("ticker")
 
 

--- a/tests/test_edgar_fetcher.py
+++ b/tests/test_edgar_fetcher.py
@@ -1,0 +1,48 @@
+import types
+
+from scrapers import edgar
+
+
+class DummyResp:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_edgar_facts_success(monkeypatch):
+    def fake_get(url, timeout=10):
+        if "ticker" in url:
+            return DummyResp(200, {"cik_str": "1234"})
+        return DummyResp(
+            200,
+            {
+                "facts": {
+                    "CashAndCashEquivalentsAtCarryingValue": {
+                        "units": {"USD": [{"val": 1000}]}
+                    },
+                    "CommonStockSharesOutstanding": {
+                        "units": {"shares": [{"val": 50}]}
+                    },
+                    "Debt": {"units": {"USD": [{"val": 25}]}}
+                }
+            },
+        )
+
+    monkeypatch.setattr(edgar, "session", types.SimpleNamespace(get=fake_get))
+    monkeypatch.setattr(edgar, "time", types.SimpleNamespace(sleep=lambda *_: None))
+    data = edgar.fetch_edgar_facts("AAPL")
+    assert data["totalCash"] == 1000
+    assert data["sharesOutstanding"] == 50
+    assert data["totalDebt"] == 25
+
+
+def test_fetch_edgar_facts_failure(monkeypatch):
+    def fake_get(url, timeout=10):
+        return DummyResp(404, {})
+
+    monkeypatch.setattr(edgar, "session", types.SimpleNamespace(get=fake_get))
+    monkeypatch.setattr(edgar, "time", types.SimpleNamespace(sleep=lambda *_: None))
+    assert edgar.fetch_edgar_facts("MSFT") == {}

--- a/tests/test_full_fundamentals.py
+++ b/tests/test_full_fundamentals.py
@@ -1,0 +1,21 @@
+from scrapers import full_fundamentals as ff
+
+
+class DummyTicker:
+    def __init__(self, *_, **__):
+        pass
+
+    def get_info(self):
+        raise ff.HTTPError("401")
+
+    @property
+    def fast_info(self):
+        raise Exception("fail")
+
+
+def test_fetch_fundamentals_edgar_fallback(monkeypatch):
+    monkeypatch.setattr(ff.yf, "Ticker", lambda *a, **k: DummyTicker())
+    monkeypatch.setattr(ff, "fetch_edgar_facts", lambda s: {"sharesOutstanding": 99})
+    monkeypatch.setattr(ff.time, "sleep", lambda *_: None)
+    data = ff.fetch_fundamentals("ABC")
+    assert data == {"sharesOutstanding": 99}


### PR DESCRIPTION
## Summary
- Add EDGAR client to retrieve cash, debt and shares from SEC as a final fallback
- Use EDGAR when Yahoo fundamentals fail and reuse wrapper in price metrics
- Document EDGAR usage and add unit tests for fetcher and fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0df4fc5c883238930f8cb73fccc5f