### PR TITLE
fix: disable pct_change forward fill

### DIFF
--- a/analytics/tracking.py
+++ b/analytics/tracking.py
@@ -51,7 +51,7 @@ def _fetch_returns(symbols: Iterable[str], days: int = 90) -> pd.DataFrame:
         closes.append(df)
 
     big = pd.concat(closes, axis=1)
-    return big.pct_change().dropna()
+    return big.pct_change(fill_method=None).dropna()
 
 
 def update_all_metrics(days: int = 90) -> None:
@@ -137,7 +137,7 @@ def _gather_metrics(symbols: Iterable[str], index_name: str) -> pd.DataFrame:
 
     spx = (
         yf.download("^GSPC", period="13mo", interval="1d", progress=False)["Close"]
-        .pct_change()
+        .pct_change(fill_method=None)
         .dropna()
     )
     today = dt.date.today()
@@ -145,7 +145,7 @@ def _gather_metrics(symbols: Iterable[str], index_name: str) -> pd.DataFrame:
     for sym in closes.columns:
         px = closes[sym].dropna()
         vol = vols[sym].reindex(px.index).ffill()
-        r = px.pct_change().dropna()
+        r = px.pct_change(fill_method=None).dropna()
         if r.empty:
             continue
         fund = compute_fundamental_metrics(sym)

--- a/risk/tasks.py
+++ b/risk/tasks.py
@@ -47,7 +47,7 @@ def _sp500_returns(days: int = 60) -> pd.Series:
     closes = pd.Series(
         [r["close"] for r in rows], index=[pd.to_datetime(r["date"]) for r in rows]
     )
-    rets = closes.pct_change().dropna()
+    rets = closes.pct_change(fill_method=None).dropna()
     return rets.tail(days)
 
 

--- a/scrapers/full_fundamentals.py
+++ b/scrapers/full_fundamentals.py
@@ -29,7 +29,7 @@ try:  # yfinance may use curl_cffi under the hood
 except Exception:  # pragma: no cover - curl_cffi optional
     pass
 
-from scrapers.universe import load_sp500, load_sp400, load_russell2000
+from scrapers.universe import load_sp400
 from scrapers.edgar import fetch_edgar_facts
 from database import init_db, top_score_coll
 from infra.github_backup import backup_records
@@ -485,7 +485,7 @@ def compute_altman(fin, bs, info):
 def build_price_metrics(
     px: pd.DataFrame, ohlcv: Dict[str, pd.DataFrame], tickers: List[str]
 ) -> pd.DataFrame:
-    rets = px.pct_change().replace([np.inf, -np.inf], np.nan)
+    rets = px.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
     rows = []
     for t in tickers:
         s = px[t].dropna() if t in px.columns else pd.Series(dtype=float)
@@ -837,9 +837,8 @@ def build_dataset(universe: Iterable[str]) -> pd.DataFrame:
 
 
 def load_default_universe() -> List[str]:
-    """Return tickers from the combined index universe."""
-    syms = set(load_sp500()) | set(load_sp400()) | set(load_russell2000())
-    return sorted(syms)
+    """Return tickers for the S&P 400 universe."""
+    return sorted(load_sp400())
 
 
 def run_scoring(universe: Iterable[str]):

--- a/scrapers/volatility_momentum.py
+++ b/scrapers/volatility_momentum.py
@@ -25,7 +25,7 @@ _VOL_N = 5
 
 
 def _score_vol_mom(px: pd.DataFrame) -> pd.DataFrame:
-    pct = px.pct_change()
+    pct = px.pct_change(fill_method=None)
     ret_52w = px.iloc[-1] / px.iloc[0] - 1
     vol_12w = pct.tail(12).std() * math.sqrt(52)
     score = ret_52w / vol_12w.replace(0, math.nan)

--- a/strategies/sector_momentum.py
+++ b/strategies/sector_momentum.py
@@ -73,7 +73,7 @@ class SectorRiskParityMomentum:
         top = ranks.head(3).index.tolist()
         if not top:
             return
-        rets = prices[top].pct_change().dropna().tail(4)
+        rets = prices[top].pct_change(fill_method=None).dropna().tail(4)
         if rets.empty:
             return
         w, cov = self._risk_parity(rets)

--- a/strategies/volatility_momentum.py
+++ b/strategies/volatility_momentum.py
@@ -35,7 +35,7 @@ class VolatilityScaledMomentum:
 
     def _rank(self, prices: pd.DataFrame) -> pd.DataFrame:
         ret_12m = prices.iloc[-1] / prices.iloc[-52] - 1
-        vol_60 = prices.pct_change().tail(12).std() * math.sqrt(52)
+        vol_60 = prices.pct_change(fill_method=None).tail(12).std() * math.sqrt(52)
         score = ret_12m / vol_60.replace(0, float("nan"))
         ranks = pd.DataFrame({"ret": ret_12m, "vol": vol_60, "score": score})
         return ranks.sort_values("score", ascending=False)


### PR DESCRIPTION
## Summary
- avoid forward-filling when computing percent changes by passing `fill_method=None`
- update scrapers, analytics, strategies, and risk helpers to align with pandas deprecation
- limit full fundamentals scraper to S&P 400 constituents only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a101c9ed188323b74562c8958c9e2e