### PR TITLE
Run scrapers after API init and expand momentum outputs

### DIFF
--- a/scrapers/sector_momentum.py
+++ b/scrapers/sector_momentum.py
@@ -18,7 +18,7 @@ from infra.data_store import append_snapshot
 from metrics import scrape_latency, scrape_errors
 
 log = get_scraper_logger(__name__)
-_SECTOR_N = 3
+_SECTOR_N = 5
 
 
 def fetch_sector_momentum_summary(weeks: int = 26, top_n: int = _SECTOR_N) -> List[dict]:

--- a/scrapers/volatility_momentum.py
+++ b/scrapers/volatility_momentum.py
@@ -21,7 +21,7 @@ from metrics import scrape_latency, scrape_errors
 from scrapers.wiki import load_universe_any
 
 log = get_scraper_logger(__name__)
-_VOL_N = 5
+_VOL_N = 15
 
 
 def _score_vol_mom(px: pd.DataFrame) -> pd.DataFrame:
@@ -96,5 +96,5 @@ def fetch_volatility_momentum_summary(
 
 
 if __name__ == "__main__":
-    rows = fetch_volatility_momentum_summary(top_n=5, max_tickers=50)
+    rows = fetch_volatility_momentum_summary(top_n=15, max_tickers=50)
     print(f"ROWS={len(rows)}")


### PR DESCRIPTION
## Summary
- expand volatility momentum output to top 15 tickers
- persist top 5 sector ETFs for sector momentum
- launch scrapers in background after FastAPI startup to avoid blocking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee9045888323889acadfaa4014ed