### PR TITLE
chore: remove scrapers from bootstrap sequence

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@
 Assorted command-line tools.
 - `bootstrap.py` now delegates to `service.start.main`; it simply runs the
   system checklist and then launches the full startup sequence.
-- `bootstrap.sh` assumes the repo is already downloaded, installs requirements, runs all scrapers once and registers a systemd service. The MariaDB user and database are created automatically.
+- `bootstrap.sh` assumes the repo is already downloaded, installs requirements and registers a systemd service. The MariaDB user and database are created automatically. Run scrapers manually if data backfilling is required.
 - `setup_redis.sh` installs Redis, configures the bind address and enables the systemd service.
 - `health_check.py` reports system status including portfolio and metric counts.
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,7 +32,9 @@ sudo systemctl start mariadb
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS quant_fund;"
 sudo mysql -e "GRANT ALL PRIVILEGES ON quant_fund.* TO 'maria'@'%' IDENTIFIED BY 'maria'; FLUSH PRIVILEGES;"
 python -m playwright install chromium
-python "$APP_DIR/scripts/populate.py"
+# Scrapers are intentionally excluded from bootstrap to avoid noisy console
+# output and to keep deployment idempotent. Run `scripts/populate.py`
+# manually once the service is up if data backfilling is required.
 
 
 # Register the service


### PR DESCRIPTION
## Summary
- stop bootstrap.sh from running scrapers
- document that scrapers must be run manually

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24288e83c8323979be8170abfc2a6