### PR TITLE
Fix bootstrap to static IP and report API startup

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 
 APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 VENV_DIR="$APP_DIR/venv"
-# Derive the application IP from service configuration
-APP_IP=$(grep '^REDIS_URL:' "$APP_DIR/service/config.yaml" | sed -E 's/.*@([0-9.]+):.*/\1/')
+# Use the fixed application IP required by infrastructure
+APP_IP="192.168.0.59"
 
 # Create or activate virtual environment
 if [ ! -d "$VENV_DIR" ]; then
@@ -65,4 +65,5 @@ echo "Waiting for API to become available"
 until curl -sf "http://${APP_IP}:8001/health" >/dev/null; do
   sleep 2
 done
+echo "API is on at http://${APP_IP}:8001"
 echo "Bootstrap complete. Service portfolio is running."

--- a/service/start.py
+++ b/service/start.py
@@ -126,6 +126,7 @@ async def main(host: str | None = None, port: int | None = None) -> None:
             resp = await client.get(f"http://{h}:{p}/health", timeout=10)
             resp.raise_for_status()
         log.info(f"API running on http://{h}:{p} - Swagger UI: http://{h}:{p}/docs")
+        log.info("API is on")
     except Exception as exc:  # pragma: no cover - network optional
         log.warning(f"api connection FAIL: {exc}")
         raise


### PR DESCRIPTION
## Summary
- pin bootstrap to infrastructure IP `192.168.0.59`
- emit explicit "API is on" messages after startup for operator clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5f404d70883239293303bdbf1ded5