### PR TITLE
Schedule nightly DB backups

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -468,8 +468,13 @@ def init_db() -> None:
                             # Fallback for MariaDB <10.5
                             try:
                                 cur.execute(
-                                    f"ALTER TABLE {table} DROP COLUMN {column}"
+                                    f"SHOW COLUMNS FROM {table} LIKE %s",
+                                    (column,),
                                 )
+                                if cur.fetchone():
+                                    cur.execute(
+                                        f"ALTER TABLE {table} DROP COLUMN {column}"
+                                    )
                             except pymysql.err.OperationalError as inner_exc:
                                 if inner_exc.args and inner_exc.args[0] not in {
                                     1054,
@@ -489,16 +494,12 @@ def init_db() -> None:
                 if drop_idx:
                     table, index = drop_idx.groups()
                     try:
-                        cur.execute(
-                            f"ALTER TABLE {table} DROP INDEX IF EXISTS {index}"
-                        )
+                        cur.execute(f"ALTER TABLE {table} DROP INDEX IF EXISTS {index}")
                     except pymysql.err.OperationalError as exc:
                         if exc.args and exc.args[0] == 1064:
                             # Fallback for MariaDB <10.5
                             try:
-                                cur.execute(
-                                    f"ALTER TABLE {table} DROP INDEX {index}"
-                                )
+                                cur.execute(f"ALTER TABLE {table} DROP INDEX {index}")
                             except pymysql.err.OperationalError as inner_exc:
                                 if inner_exc.args and inner_exc.args[0] not in {
                                     1091,

--- a/service/config.py
+++ b/service/config.py
@@ -151,6 +151,7 @@ DEFAULT_SCHEDULES = {
     "ticker_scores": "0 3 1 * *",
     "wsb_mentions": "0 3 * * *",
     "account": "0 0 * * *",
+    "db_backup": "0 1 * * *",
     "risk_stats": "30 0 * * *",
     "risk_rules": "*/5 * * * *",
     "politician_trades": "0 2 * * *",

--- a/tests/test_backup_failure.py
+++ b/tests/test_backup_failure.py
@@ -1,0 +1,16 @@
+import subprocess
+
+import pytest
+
+from database import backup
+
+
+def test_backup_to_github_propagates_git_errors(monkeypatch, tmp_path):
+    monkeypatch.setattr(backup, "_dump_tables", lambda: [tmp_path / "t.json"])
+
+    def fail(cmd, check):  # pragma: no cover - simulated failure
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(backup.subprocess, "run", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        backup.backup_to_github()

--- a/tests/test_db_backup_schedule.py
+++ b/tests/test_db_backup_schedule.py
@@ -1,0 +1,7 @@
+from service.scheduler import StrategyScheduler
+
+
+def test_scheduler_registers_db_backup():
+    sched = StrategyScheduler()
+    sched.register_jobs()
+    assert sched.scheduler.get_job("db_backup") is not None


### PR DESCRIPTION
## Summary
- schedule nightly database backups via new `db_backup` job
- make `backup_to_github` raise on missing DB or git failures
- test nightly backup scheduling and failure propagation

## Testing
- `python -m black database/backup.py service/config.py service/scheduler.py tests/test_db_backup_schedule.py tests/test_backup_failure.py`
- `pytest -q && echo 'PYTEST_OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b757c46d248323b3311f3fea8cff35