### PR TITLE
Handle missing tables for wiki ticker scrape

### DIFF
--- a/scrapers/universe.py
+++ b/scrapers/universe.py
@@ -63,8 +63,15 @@ def _clean_symbols(symbols: List[str]) -> List[str]:
 
 
 def _tickers_from_wiki(url: str) -> List[str]:
-    html = requests.get(url, timeout=30).text
-    dfs = pd.read_html(StringIO(html))
+    """Fetch ticker symbols from a Wikipedia table."""
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; PortfolioBot/1.0)"}
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    try:
+        dfs = pd.read_html(StringIO(response.text))
+    except ValueError as exc:
+        log.error("no tables found at %s: %s", url, exc)
+        return []
     out: list[str] = []
     for tbl in dfs:
         for col in tbl.columns:

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -95,6 +95,17 @@ def test_helpers(monkeypatch, tmp_path):
     print(data2.iloc[0].to_dict())
 
 
+def test_tickers_from_wiki_no_table(monkeypatch):
+    class Resp:
+        text = "<html></html>"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(univ.requests, "get", lambda *a, **k: Resp())
+    assert univ._tickers_from_wiki("http://example.com") == []
+
+
 @mock.patch.object(vm, "append_snapshot")
 @mock.patch.object(vm, "vol_mom_coll", new=mock.Mock())
 @mock.patch.object(vm, "load_universe_any")


### PR DESCRIPTION
## Summary
- harden `_tickers_from_wiki` with User-Agent header and HTTP status checks
- log and return an empty list when Wikipedia pages lack tables
- cover missing-table path in scraper tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77807a6f08323b05a2c0273407dfe